### PR TITLE
Add a faster version of the slow bits of script/update

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ script/server
 
 The site will be visible at <http://localhost:8000>.
 
-# Get and preprocess data (includes setting up a Solr text index for the plan document text)
+# Get, preprocess and load council, plan, and emissions data (includes setting up a Solr text index for the plan document text)
 
 ```
 script/update
@@ -33,9 +33,10 @@ script/update
 
 The Solr server interface will be visible at <http://localhost:8983>
 
-# Get and load emissions data
+This will take some shortcuts if you already have some data loaded in order to run reasonably quickly.
+For a comprehensive update, use:
 
 ```
-script/manage import_emissions_data
+script/update --all
 ```
 

--- a/caps/management/commands/add_text.py
+++ b/caps/management/commands/add_text.py
@@ -9,7 +9,19 @@ import pdftotext
 from django.core.management.base import BaseCommand, CommandError
 from django.conf import settings
 
-def add_text_to_csv():
+from caps.models import PlanDocument
+
+def generate_text(pdf_path, df, index):
+
+    with open(pdf_path, "rb") as f:
+        pdf_filename = basename(pdf_path)
+        try:
+            pdf = pdftotext.PDF(f)
+            df.at[index, 'text'] = " ".join(pdf).replace('\n', ' ')
+        except pdftotext.Error as err:
+            print(f"Error getting PDF text for {pdf_filename}")
+
+def add_text_to_csv(get_all):
     df = pd.read_csv(settings.PROCESSED_CSV)
     rows = len(df['council'])
 
@@ -20,15 +32,19 @@ def add_text_to_csv():
     pdf_rows = df['file_type'] == 'pdf'
     for index, row in df[pdf_rows].iterrows():
         filename = basename(row['plan_path'])
+        url = row['url']
+        url_hash = PlanDocument.make_url_hash(url)
+        council = row['council']
         pdf_path = join(settings.PLANS_DIR, filename)
-        with open(pdf_path, "rb") as f:
-            pdf_filename = basename(pdf_path)
-            index = df[df['plan_path'] == pdf_filename].index.values[0]
+        if get_all:
+            generate_text(pdf_path, df, index)
+        else:
             try:
-                pdf = pdftotext.PDF(f)
-                df.at[index, 'text'] = " ".join(pdf).replace('\n', ' ')
-            except pdftotext.Error as err:
-                print(f"Error getting PDF text for {pdf_filename}")
+                plan_document = PlanDocument.objects.get(url_hash=url_hash, council__name=council)
+                df.at[index, 'text'] = plan_document.text
+            except PlanDocument.DoesNotExist:
+                generate_text(pdf_path, df, index)
+
 
     # save the CSV
     df.to_csv(open(settings.PROCESSED_CSV, "w"), index=False, header=True)
@@ -36,7 +52,14 @@ def add_text_to_csv():
 class Command(BaseCommand):
     help = 'Adds text to the csv of plans'
 
-    def handle(self, *args, **options):
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--all',
+            action='store_true',
+            help='Update all data (slower but more thorough)',
+        )
 
+    def handle(self, *args, **options):
+        get_all = options['all']
         print("adding text to the csv")
-        add_text_to_csv()
+        add_text_to_csv(get_all)

--- a/caps/management/commands/add_text.py
+++ b/caps/management/commands/add_text.py
@@ -9,8 +9,6 @@ import pdftotext
 from django.core.management.base import BaseCommand, CommandError
 from django.conf import settings
 
-PUBLISH_URL = 'https://council-climate-action-plans.herokuapp.com/static/'
-
 def add_text_to_csv():
     df = pd.read_csv(settings.PROCESSED_CSV)
     rows = len(df['council'])

--- a/caps/management/commands/import_emissions_data.py
+++ b/caps/management/commands/import_emissions_data.py
@@ -106,14 +106,25 @@ def convert_emissions_data():
 class Command(BaseCommand):
     help = 'Imports emissions data by council'
 
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--all',
+            action='store_true',
+            help='Update all data (slower but more thorough)',
+        )
+
     def handle(self, *args, **options):
-        print('getting data files')
-        get_data_files()
-        print('converting emissions data')
-        convert_emissions_data()
-        print('creating data types')
-        create_data_types()
-        print('importing emissions data')
-        import_emissions_data()
-        print('checking completeness')
-        check_completeness()
+        get_all = options['all']
+        if not get_all and DataPoint.objects.count() > 0:
+            print("emissions data exists, skipping")
+        else:
+            print('getting data files')
+            get_data_files()
+            print('converting emissions data')
+            convert_emissions_data()
+            print('creating data types')
+            create_data_types()
+            print('importing emissions data')
+            import_emissions_data()
+            print('checking completeness')
+            check_completeness()

--- a/caps/management/commands/import_plans.py
+++ b/caps/management/commands/import_plans.py
@@ -33,8 +33,7 @@ class Command(BaseCommand):
             print(row)
 
             if not pd.isnull(row['url']):
-                plan_filename = PlanDocument.plan_filename(row['council'], row['url'])
-                document_file = open(join(settings.PLANS_DIR, plan_filename), "rb")
+                document_file = open(row['plan_path'], "rb")
                 file_object = File(document_file)
                 (start_year, end_year) = PlanDocument.start_and_end_year_from_time_period(row['time_period'])
                 plan_document = PlanDocument.objects.get_or_create(

--- a/caps/management/commands/import_plans.py
+++ b/caps/management/commands/import_plans.py
@@ -30,7 +30,6 @@ class Command(BaseCommand):
                 mapit_area_code = PlanDocument.char_from_text(row['mapit_area_code']),
                 website_url = PlanDocument.char_from_text(row['website_url']),
             )
-            print(row)
 
             if not pd.isnull(row['url']):
                 document_file = open(row['plan_path'], "rb")
@@ -57,7 +56,3 @@ class Command(BaseCommand):
                                 'file': file_object
                                 }
                 )
-
-
-                print(file_object)
-                # plan_document.file.save(plan_filename, file_object, save=True)

--- a/caps/management/commands/preprocess.py
+++ b/caps/management/commands/preprocess.py
@@ -38,50 +38,49 @@ def set_file_attributes(df, index, content_type, extension):
     else:
         print("Unknown content type: " + content_type)
 
-class MissingContentTypeException(Exception):
-    pass
-
-def check_or_get(url, headers, local_path, retry=False):
-    # If we already have a plan, try just checking the headers before getting it again
-    try:
-        if os.path.isfile(local_path) and not retry:
-            method = 'HEAD'
-            r = requests.head(url, headers=headers, verify=False)
-        else:
-            method = 'GET'
-            r = requests.get(url, headers=headers, verify=False)
-        r.raise_for_status()
-        if r.headers.get('content-type') is None:
-            raise MissingContentTypeException
-    except (requests.exceptions.RequestException, MissingContentTypeException) as err:
-        if method == 'HEAD':
-            return check_or_get(url, headers, local_path, retry=True)
-        else:
-            raise err
-    return r
-
 def get_plan(row, index, df):
     url = row['url']
     council = row['council']
+    new_filename = PlanDocument.plan_filename(council, url)
     url_parts = urlparse(url)
     filepath, extension = splitext(url_parts.path)
-    new_filename = PlanDocument.plan_filename(row['council'], row['url'])
-    local_path = join(settings.PLANS_DIR, new_filename)
     headers = {
             'User-Agent': 'mySociety Council climate action plans search',
     }
     try:
-        r = check_or_get(url, headers, local_path)
+        r = requests.get(url, headers=headers, verify=False)
+        r.raise_for_status()
         set_file_attributes(df, index, r.headers.get('content-type'), extension)
-        df.at[index, 'plan_path'] = new_filename
-        if not os.path.isfile(local_path):
-            with open(local_path, 'wb') as outfile:
-                outfile.write(r.content)
-    except (requests.exceptions.RequestException, MissingContentTypeException) as err:
+        new_filename = new_filename + '.' + df.at[index, 'file_type']
+        local_path = join(settings.PLANS_DIR, new_filename)
+        df.at[index, 'plan_path'] = local_path
+        with open(local_path, 'wb') as outfile:
+            outfile.write(r.content)
+    except requests.exceptions.RequestException as err:
         print(f"Error {council} {url}: {err}")
         df.at[index, "url"] = numpy.nan
 
-def get_individual_plans():
+
+def update_plan(row, index, df, get_all):
+    url = row['url']
+    council = row['council']
+    url_hash = PlanDocument.make_url_hash(url)
+    new_filename = PlanDocument.plan_filename(council, url)
+    if get_all:
+        get_plan(row, index, df)
+    else:
+        # If we've already loaded a document from this URL, don't get the file again
+        try:
+            plan_document = PlanDocument.objects.get(url_hash=url_hash, council__name=council)
+            df.at[index, 'charset'] = plan_document.charset
+            df.at[index, 'file_type'] = plan_document.file_type
+            new_filename = new_filename + '.' + plan_document.file_type
+            local_path = join(settings.PLANS_DIR, new_filename)
+            df.at[index, 'plan_path'] = local_path
+        except PlanDocument.DoesNotExist:
+            get_plan(row, index, df)
+
+def get_individual_plans(get_all):
     df = pd.read_csv(settings.PROCESSED_CSV)
     rows = len(df['council'])
 
@@ -94,7 +93,7 @@ def get_individual_plans():
 
     rows_with_urls = df['url'].notnull()
     for index, row in df[rows_with_urls].iterrows():
-        get_plan(row, index, df)
+        update_plan(row, index, df, get_all)
 
     df.to_csv(open(settings.PROCESSED_CSV, "w"), index=False, header=True)
 
@@ -129,11 +128,18 @@ def replace_headers():
 class Command(BaseCommand):
     help = 'Preprocesses plans csv data'
 
-    def handle(self, *args, **options):
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--all',
+            action='store_true',
+            help='Update all data (slower but more thorough)',
+        )
 
+    def handle(self, *args, **options):
+        get_all = options['all']
         print("getting the csv")
         get_plans_csv()
         print("replacing headers")
         replace_headers()
         print('getting plans')
-        get_individual_plans()
+        get_individual_plans(get_all)

--- a/caps/management/commands/preprocess.py
+++ b/caps/management/commands/preprocess.py
@@ -19,8 +19,6 @@ from caps.models import PlanDocument
 import ssl
 
 
-PUBLISH_URL = 'https://council-climate-action-plans.herokuapp.com/static/'
-
 ssl._create_default_https_context = ssl._create_unverified_context
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 

--- a/script/update
+++ b/script/update
@@ -6,11 +6,12 @@ set -e
 # check that we are in the expected directory
 cd `dirname $0`/..
 
-"$(dirname "$0")/manage" preprocess
+
+"$(dirname "$0")/manage" preprocess  "$@"
 "$(dirname "$0")/manage" add_authority_codes
 "$(dirname "$0")/manage" add_council_websites
-"$(dirname "$0")/manage" add_text
+"$(dirname "$0")/manage" add_text "$@"
 "$(dirname "$0")/manage" import_plans
 "$(dirname "$0")/manage" link_combined_authorities
-"$(dirname "$0")/manage" import_emissions_data
 "$(dirname "$0")/manage" rebuild_index --noinput
+"$(dirname "$0")/manage" import_emissions_data "$@"


### PR DESCRIPTION
This allows cached data to be used on a standard run of `script/update` (if any data has previously been loaded). A run with the flag `script/update --all` will produce a comprehensive update. It's worth noting that it's not necessary to run `script/update` every time a vagrant box is restarted - it basically just loads data, rather than updating the code or dependencies. 

Fixes #42
Fixes #36 