### PR TITLE
Bump various dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,6 @@ django-pipeline==1.6.14
 et-xmlfile==1.0.1
 feedparser==5.2.1
 future-fstrings==1.2.0
-futures==3.0.5
 gunicorn==20.0.4
 html5lib==1.1
 idna==2.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ chardet==3.0.4
 csscompressor==0.9.4
 defusedxml==0.6.0
 diff-match-patch==20200713
-Django==2.2.8
+Django==2.2.20
 django-autoslug==1.9.7
 django-bootstrap4==1.1.1
 django-filter==2.4.0
@@ -31,14 +31,14 @@ olefile==0.44
 openpyxl==2.6.4
 pandas==0.25.3
 pdftotext==2.1.5
-Pillow==6.2.0
+Pillow==8.1.1
 psycopg2==2.8.5
 pysolr==3.9.0
 python-dateutil==2.8.1
 python-slugify==4.0.1
 pytz==2020.1
-PyYAML==4.2b1
-requests==2.24.0
+PyYAML==5.4
+requests==2.25.1
 requests-cache==0.5.2
 six==1.10.0
 soupsieve==2.0.1
@@ -46,7 +46,7 @@ sqlparse==0.4.1
 tablib==2.0.0
 text-unidecode==1.3
 tokenize-rt==3.2.0
-urllib3==1.25.10
+urllib3==1.26.5
 webencodings==0.5.1
 xlrd==1.2.0
 xlwt==1.3.0


### PR DESCRIPTION
This updates requests, urllib3, pillow, django and pyyaml. The latter four were flagged individually by Dependabot; the urllib3 tests failed due to the need to update requests as a dependency.