### PR TITLE
plan_link_click analytics event created

### DIFF
--- a/caps/templates/council_detail.html
+++ b/caps/templates/council_detail.html
@@ -72,7 +72,7 @@
         <h2>Plan documents</h2>
     </div>
   {% for plandocument in council.plandocument_set.all %}
-    <a href="{{ plandocument.link }}" class="d-flex p-3 align-items-center">
+    <a href="{{ plandocument.link }}" data-plan-id="{{ plandocument.id }}" data-council-slug="{{ council.slug }}" class="d-flex p-3 align-items-center">
         {% include 'icons/file.html' with classes='mr-2 flex-shrink-0' %}
         {{ council.name }} {{ plandocument.document_name|title }} ({{ plandocument.file_type|upper }})
     </a>

--- a/caps/templates/includes/text-search-result.html
+++ b/caps/templates/includes/text-search-result.html
@@ -1,7 +1,7 @@
 <div class="ceuk-card card mb-3 mb-lg-4">
     <div class="card-body mb-n3">
         <h2 class="h4"><a href="{% url 'council' result.object.council.slug %}">{{ result.object.council.name }}</a></h2>
-        <a class="d-flex align-items-center mb-3" href="{{ result.object.file.url }}">
+        <a class="d-flex align-items-center mb-3" data-plan-id="{{ result.object.id }}" data-council-slug="{{ result.object.council.slug }}" href="{{ result.object.file.url }}">
             {% include 'icons/file.html' with classes='mr-2' %}
             Direct link to {{ result.object.document_name }} ({{ result.object.file_type|upper }})
         </a>


### PR DESCRIPTION
This PR solves a problem where the GA `file_download` event does not always make it easy to link back to the council the file is associated with. 

This explicitly tags up links in the council and search page with the council slug, and has a `gtag` function that catches these links and triggers a `plan_link_click` event. 