### PR TITLE
Django intermediary between survey and mailchimp

### DIFF
--- a/caps/static/js/main.js
+++ b/caps/static/js/main.js
@@ -162,6 +162,18 @@ $('#interstitial-modal').on('shown.bs.modal', function(e){
     $('#interstitial-modal [data-toggle="tooltip"]').tooltip();
 }).modal('show');
 
+    $("#survey-submit").on("click", function(e){
+
+        email = $("#interstitial-email").val()
+        csrftoken = document.querySelector('[name=csrfmiddlewaretoken]').value;
+        if (email != ''){
+            $.post("/ajax/mailchimp_email", {email: email,
+                        csrfmiddlewaretoken: csrftoken
+                        })
+        }
+    })
+
+
 $('.conditional-fields').each(function(){
     var $conditional = $(this);
     var $prevInput = $(this).prev().find('input');
@@ -196,3 +208,5 @@ var trackEvent = function(eventName, params) {
 
     return dfd.promise();
 };
+
+

--- a/caps/templates/includes/interstitial-modal.html
+++ b/caps/templates/includes/interstitial-modal.html
@@ -8,6 +8,7 @@
             </div>
 
             <form class="modal-body">
+                {% csrf_token %}
                 <div class="team-avatars">
                     <div class="team-avatars__person" data-toggle="tooltip" data-placement="bottom" title="Louise">
                         <img src="https://via.placeholder.com/100" width="100" height="100" alt="">
@@ -88,7 +89,7 @@
             </form>
 
             <div class="modal-footer">
-                <button type="submit" class="btn btn-primary btn-lg">Save answers</button>
+                <button id="survey-submit" type="submit" class="btn btn-primary btn-lg">Save answers</button>
             </div>
 
         </div>

--- a/caps/urls.py
+++ b/caps/urls.py
@@ -12,6 +12,7 @@ urlpatterns = [
     path('councils/', views.CouncilListView.as_view(), name='council_list'),
     path('location/', views.LocationResultsView.as_view(), name='location_results'),
     path('about/', views.AboutView.as_view(), name='about'),
+    path('ajax/mailchimp_email', views.MailchimpView.as_view(), name='mailchimp_hook'),
     path('admin/', admin.site.urls),
 
 ]

--- a/caps/views.py
+++ b/caps/views.py
@@ -1,9 +1,12 @@
 # -*- coding: future_fstrings -*-
 from django.shortcuts import render
-from django.http import HttpResponse
-from django.views.generic import DetailView, ListView, TemplateView
+from django.http import HttpResponse, JsonResponse
+from django.views.generic import View, DetailView, ListView, TemplateView
 from django.db.models import Q, Count, Max
 from django.shortcuts import redirect
+from django.conf import settings
+import mailchimp_marketing as MailchimpMarketing
+from mailchimp_marketing.api_client import ApiClientError
 
 from django_filters.views import FilterView
 from haystack.generic_views import SearchView as HaystackSearchView
@@ -98,3 +101,35 @@ class LocationResultsView(TemplateView):
 class AboutView(TemplateView):
 
     template_name = "about.html"
+
+
+class MailchimpView(View):
+    """
+    View that accepts a post request of an email address
+    and adds that to the mailchimp list
+    """
+
+    def post(self, request):
+
+        email = request.POST.get("email")
+        client = MailchimpMarketing.Client()
+        client.set_config({
+            "api_key": settings.MAILCHIMP_KEY,
+            "server": settings.MAILCHIMP_SERVER_PREFIX
+        })
+
+        content = {"email_address":email,
+                   "status":"subscribed"}
+        result = None
+        body = {"members":[content],
+                "update_existing": True}
+
+        success = False
+        try:
+            result = client.lists.batch_list_members(settings.MAILCHIMP_LIST_ID, body)
+            success = True
+        except ApiClientError as error:
+            print("Error: {}".format(error.text))
+            success = False
+
+        return JsonResponse({"result":success})

--- a/conf/config.py.docker
+++ b/conf/config.py.docker
@@ -20,3 +20,7 @@ SOLR_ADMIN_URL = os.environ.get("SOLR_ADMIN_URL", "http://solr:8983/solr/admin/c
 SURVEY_URL = os.environ.get("SURVEY_URL", "https://survey.alchemer.com/s3/6421904/Climate-Action-Plans-User-Survey")
 
 GOOGLE_ANALYTICS = os.environ.get("GOOGLE_ANALYTICS", "xxx")
+
+MAILCHIMP_KEY = os.environ.get("MAILCHIMP_KEY", "")
+MAILCHIMP_SERVER_PREFIX = os.environ.get("MAILCHIMP_SERVER_PREFIX", "us9")
+MAILCHIMP_LIST_ID = os.environ.get("MAILCHIMP_LIST_ID", "48e077419a")

--- a/development.yml
+++ b/development.yml
@@ -15,6 +15,7 @@ services:
       - SECRET_KEY=${SECRET_KEY:-xx}
       - DEBUG=${DEBUG:-1}
       - MAPIT_API_KEY=${MAPIT_API_KEY:-xxx}
+      - MAILCHIMP_KEY=${MAILCHIMP_KEY:-xxx}
     depends_on:
       - postgres
       - solr

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,3 +49,4 @@ urllib3==1.26.5
 webencodings==0.5.1
 xlrd==1.2.0
 xlwt==1.3.0
+git+https://github.com/mailchimp/mailchimp-marketing-python.git@a734b605fe457f429144ec81c7ba721f47ad4e57#egg=mailchimp_marketing


### PR DESCRIPTION
Obviously rewrite the JS bit as you like, but in principle creates a local hook for adding an email to the survey queue.

You need to add MAILCHIMP_KEY to the .env file - you can source the CAPS key from https://us9.admin.mailchimp.com/account/api/

(Not sure where we'd need to add that to deploy properly)