### PR TITLE
Small tweaks for future proofing

### DIFF
--- a/caps/import_utils.py
+++ b/caps/import_utils.py
@@ -1,0 +1,127 @@
+from os.path import join
+
+import requests
+import urllib3
+
+import pandas as pd
+
+from django.conf import settings
+
+import ssl
+
+ssl._create_default_https_context = ssl._create_unverified_context
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+AUTHORITY_MAPPING_URL = 'https://raw.githubusercontent.com/crowbot/uk_local_authority_names_and_codes/master/lookup_name_to_registry.csv'
+AUTHORITY_MAPPING_NAME = 'lookup_name_to_registry.csv'
+AUTHORITY_MAPPING = join(settings.DATA_DIR, AUTHORITY_MAPPING_NAME)
+
+AUTHORITY_DATA_URL = 'https://raw.githubusercontent.com/crowbot/uk_local_authority_names_and_codes/master/uk_local_authorities.csv'
+AUTHORITY_DATA_NAME = 'uk_local_authorities.csv'
+AUTHORITY_DATA = join(settings.DATA_DIR, AUTHORITY_DATA_NAME)
+
+COMBINED_AUTHORITY_DATA_URL = 'http://geoportal1-ons.opendata.arcgis.com/datasets/43d30f924b29452b881e1820dcf897f9_0.csv'
+COMBINED_AUTHORITY_DATA_NAME = 'combined_authorities.csv'
+COMBINED_AUTHORITY_DATA = join(settings.DATA_DIR, COMBINED_AUTHORITY_DATA_NAME)
+
+def get_data_files():
+
+    data_files = [(AUTHORITY_MAPPING_URL, AUTHORITY_MAPPING),
+                  (AUTHORITY_DATA_URL, AUTHORITY_DATA),
+                  (COMBINED_AUTHORITY_DATA_URL, COMBINED_AUTHORITY_DATA)]
+
+    for (source, destination) in data_files:
+        r = requests.get(source)
+        with open(destination, 'wb') as outfile:
+            outfile.write(r.content)
+
+def add_authority_codes(filename):
+    mapping_df = pd.read_csv(AUTHORITY_MAPPING)
+
+    plans_df = pd.read_csv(filename)
+
+    rows = len(plans_df['council'])
+
+    plans_df['authority_code'] = pd.Series([None] * rows, index=plans_df.index)
+
+    names_to_codes = {}
+    for index, row in mapping_df.iterrows():
+        names_to_codes[row['la name'].lower()] = row['local-authority-code']
+
+    for index, row in plans_df.iterrows():
+        council = row['council'].lower()
+
+        name_versions = [council, council.replace('council', '').strip(), council.replace('- unitary', '').replace('(unitary)', '').strip()]
+        for version in name_versions:
+            if version in names_to_codes:
+                plans_df.at[index, 'authority_code'] = names_to_codes[version]
+                break
+    plans_df.to_csv(open(filename, "w"), index=False, header=True)
+
+def add_gss_codes(filename):
+
+    authority_df = pd.read_csv(AUTHORITY_DATA)
+    plans_df = pd.read_csv(filename)
+
+    rows = len(plans_df['council'])
+    plans_df['gss_code'] = pd.Series([None] * rows, index=plans_df.index)
+
+    for index, row in plans_df.iterrows():
+        authority_code = row['authority_code']
+        if not pd.isnull(authority_code):
+            authority_match = authority_df[authority_df['local-authority-code'] == authority_code]
+            plans_df.at[index, 'gss_code'] = authority_match['gss-code'].values[0]
+
+    plans_df.to_csv(open(filename, "w"), index=False, header=True)
+
+def add_extra_authority_info(filename):
+
+    authority_df = pd.read_csv(AUTHORITY_DATA)
+    plans_df = pd.read_csv(filename)
+
+    rows = len(plans_df['council'])
+    plans_df['authority_type'] = pd.Series([None] * rows, index=plans_df.index)
+    plans_df['wdtk_id'] = pd.Series([None] * rows, index=plans_df.index)
+    plans_df['mapit_area_code'] = pd.Series([None] * rows, index=plans_df.index)
+    plans_df['country'] = pd.Series([None] * rows, index=plans_df.index)
+    plans_df['gss_code'] = pd.Series([None] * rows, index=plans_df.index)
+
+    for index, row in plans_df.iterrows():
+        authority_code = row['authority_code']
+        if not pd.isnull(authority_code):
+            authority_match = authority_df[authority_df['local-authority-code'] == authority_code]
+            country = None
+            country = authority_match['nation'].values[0]
+            plans_df.at[index, 'authority_type'] = authority_match['local-authority-type'].values[0]
+            plans_df.at[index, 'wdtk_id'] = authority_match['wdtk_ids'].values[0]
+            plans_df.at[index, 'mapit_area_code'] = authority_match['mapit_area_code'].values[0]
+            plans_df.at[index, 'country'] = country
+            plans_df.at[index, 'gss_code'] = authority_match['gss-code'].values[0]
+
+            # All authorities in Wales, Scotland and Northern Ireland are unitary
+            if country in ['Wales', 'Scotland', 'Northern Ireland']:
+                plans_df.at[index, 'authority_type'] = 'UA'
+    plans_df.to_csv(open(filename, "w"), index=False, header=True)
+
+def add_combined_authority_gss_codes(filename):
+    plans_df = pd.read_csv(filename)
+    combined_authority_df = pd.read_csv(COMBINED_AUTHORITY_DATA)
+
+    aliases = {'newcastle upon tyne, north tyneside and northumberland combined authority': 'north of tyne'}
+
+    names_to_codes = {}
+    for index, row in combined_authority_df.iterrows():
+        names_to_codes[row['CAUTH19NM'].lower()] = row['CAUTH19CD']
+    for index, row in plans_df.iterrows():
+        council = row['council'].lower()
+        if row['authority_type'] == 'COMB':
+            name_versions = [council, council.replace('combined authority', '').strip()]
+            if council in aliases:
+                name_versions.append(aliases[council])
+            for version in name_versions:
+                if version in names_to_codes:
+                    plans_df.at[index, 'gss_code'] = names_to_codes[version]
+                    break
+
+    plans_df.to_csv(open(filename, "w"), index=False, header=True)
+

--- a/caps/management/commands/add_authority_codes.py
+++ b/caps/management/commands/add_authority_codes.py
@@ -8,81 +8,9 @@ import pandas as pd
 from django.core.management.base import BaseCommand, CommandError
 from django.conf import settings
 
-AUTHORITY_MAPPING_URL = 'https://raw.githubusercontent.com/crowbot/uk_local_authority_names_and_codes/master/lookup_name_to_registry.csv'
-AUTHORITY_MAPPING_NAME = 'lookup_name_to_registry.csv'
-AUTHORITY_MAPPING = join(settings.DATA_DIR, AUTHORITY_MAPPING_NAME)
 
-AUTHORITY_DATA_URL = 'https://raw.githubusercontent.com/crowbot/uk_local_authority_names_and_codes/master/uk_local_authorities.csv'
-AUTHORITY_DATA_NAME = 'uk_local_authorities.csv'
-AUTHORITY_DATA = join(settings.DATA_DIR, AUTHORITY_DATA_NAME)
+from caps.import_utils import get_data_files, add_extra_authority_info, add_authority_codes, add_combined_authority_gss_codes
 
-COMBINED_AUTHORITY_DATA_URL = 'http://geoportal1-ons.opendata.arcgis.com/datasets/43d30f924b29452b881e1820dcf897f9_0.csv'
-COMBINED_AUTHORITY_DATA_NAME = 'combined_authorities.csv'
-COMBINED_AUTHORITY_DATA = join(settings.DATA_DIR, COMBINED_AUTHORITY_DATA_NAME)
-
-def get_data_files():
-
-    data_files = [(AUTHORITY_MAPPING_URL, AUTHORITY_MAPPING),
-                  (AUTHORITY_DATA_URL, AUTHORITY_DATA),
-                  (COMBINED_AUTHORITY_DATA_URL, COMBINED_AUTHORITY_DATA)]
-
-    for (source, destination) in data_files:
-        r = requests.get(source)
-        with open(destination, 'wb') as outfile:
-            outfile.write(r.content)
-
-def add_authority_codes():
-    mapping_df = pd.read_csv(AUTHORITY_MAPPING)
-
-    plans_df = pd.read_csv(settings.PROCESSED_CSV)
-
-    rows = len(plans_df['council'])
-
-    plans_df['authority_code'] = pd.Series([None] * rows, index=plans_df.index)
-
-    names_to_codes = {}
-    for index, row in mapping_df.iterrows():
-        names_to_codes[row['la name'].lower()] = row['local-authority-code']
-
-    for index, row in plans_df.iterrows():
-        council = row['council'].lower()
-
-        name_versions = [council, council.replace('council', '').strip(), council.replace('- unitary', '').replace('(unitary)', '').strip()]
-        for version in name_versions:
-            if version in names_to_codes:
-                plans_df.at[index, 'authority_code'] = names_to_codes[version]
-                break
-    plans_df.to_csv(open(settings.PROCESSED_CSV, "w"), index=False, header=True)
-
-
-def add_extra_authority_info():
-
-    authority_df = pd.read_csv(AUTHORITY_DATA)
-    plans_df = pd.read_csv(settings.PROCESSED_CSV)
-
-    rows = len(plans_df['council'])
-    plans_df['authority_type'] = pd.Series([None] * rows, index=plans_df.index)
-    plans_df['wdtk_id'] = pd.Series([None] * rows, index=plans_df.index)
-    plans_df['mapit_area_code'] = pd.Series([None] * rows, index=plans_df.index)
-    plans_df['country'] = pd.Series([None] * rows, index=plans_df.index)
-    plans_df['gss_code'] = pd.Series([None] * rows, index=plans_df.index)
-
-    for index, row in plans_df.iterrows():
-        authority_code = row['authority_code']
-        if not pd.isnull(authority_code):
-            authority_match = authority_df[authority_df['local-authority-code'] == authority_code]
-            country = None
-            country = authority_match['nation'].values[0]
-            plans_df.at[index, 'authority_type'] = authority_match['local-authority-type'].values[0]
-            plans_df.at[index, 'wdtk_id'] = authority_match['wdtk_ids'].values[0]
-            plans_df.at[index, 'mapit_area_code'] = authority_match['mapit_area_code'].values[0]
-            plans_df.at[index, 'country'] = country
-            plans_df.at[index, 'gss_code'] = authority_match['gss-code'].values[0]
-
-            # All authorities in Wales, Scotland and Northern Ireland are unitary
-            if country in ['Wales', 'Scotland', 'Northern Ireland']:
-                plans_df.at[index, 'authority_type'] = 'UA'
-    plans_df.to_csv(open(settings.PROCESSED_CSV, "w"), index=False, header=True)
 
 def add_missing_authorities():
     plans_df = pd.read_csv(settings.PROCESSED_CSV)
@@ -108,28 +36,6 @@ def add_missing_authorities():
     print(f"Councils without authority codes {len(missing_councils)}")
     print(missing_councils)
 
-def add_combined_authority_gss_codes():
-    plans_df = pd.read_csv(settings.PROCESSED_CSV)
-    combined_authority_df = pd.read_csv(COMBINED_AUTHORITY_DATA)
-
-    aliases = {'newcastle upon tyne, north tyneside and northumberland combined authority': 'north of tyne'}
-
-    names_to_codes = {}
-    for index, row in combined_authority_df.iterrows():
-        names_to_codes[row['CAUTH19NM'].lower()] = row['CAUTH19CD']
-    for index, row in plans_df.iterrows():
-        council = row['council'].lower()
-        if row['authority_type'] == 'COMB':
-            name_versions = [council, council.replace('combined authority', '').strip()]
-            if council in aliases:
-                name_versions.append(aliases[council])
-            for version in name_versions:
-                if version in names_to_codes:
-                    plans_df.at[index, 'gss_code'] = names_to_codes[version]
-                    break
-
-    plans_df.to_csv(open(settings.PROCESSED_CSV, "w"), index=False, header=True)
-
 class Command(BaseCommand):
     help = 'Adds authority codes to the csv of plans'
 
@@ -137,10 +43,10 @@ class Command(BaseCommand):
         print('getting data files')
         get_data_files()
         print('adding authority codes')
-        add_authority_codes()
+        add_authority_codes(settings.PROCESSED_CSV)
         print('adding authority info')
-        add_extra_authority_info()
+        add_extra_authority_info(settings.PROCESSED_CSV)
         print('adding missing authorities')
         add_missing_authorities()
         print('adding combined authority codes')
-        add_combined_authority_gss_codes()
+        add_combined_authority_gss_codes(settings.PROCESSED_CSV)

--- a/caps/templates/council_list.html
+++ b/caps/templates/council_list.html
@@ -5,29 +5,42 @@
 
 {% block content %}
 
-<div class="card ceuk-card ceuk-card--red mb-3 mb-md-4 mb-lg-5">
-    <div class="card-header">
-        <h1>Browse data from all councils</h1>
+<div class="row">
+    <div class="col-md-4">
+
+        <div class="card ceuk-card mb-gutter position-sticky" style="top: 1rem;">
+            <div class="card-body">
+                <h1 class="mb-3">All councils</h1>
+
+                <form method="get" class="mb-n3">
+                    {% bootstrap_form filter.form %}
+                    {% buttons %}
+                    <button type="submit" class="btn btn-primary btn-block mt-4">Filter list</button>
+                    {% endbuttons %}
+                </form>
+            </div>
+        </div>
+
     </div>
-    <div class="ceuk-data-table">
-        <div class="ceuk-data-table__filters">
-            <form method="get">
-                {% bootstrap_form filter.form %}
-                {% buttons %}
-                <button type="submit" class="btn btn-primary btn-sm">Filter</button>
-                {% endbuttons %}
-            </form>
+    <div class="col-md-8">
+
+        <div class="card ceuk-card ceuk-card--red mb-3 mb-md-4 mb-lg-5">
+            <div class="card-header">
+                <h3>
+                  {% if filter.qs.count == 1 %}
+                    {{ filter.qs.count }} council
+                  {% else %}
+                    {{ filter.qs.count }} councils
+                  {% endif %}
+                </h3>
+            </div>
+            <div class="ceuk-data-table">
+              {% if filter.qs %}
+                {% include 'includes/council-table.html' with councils=filter.qs %}
+              {% endif %}
+            </div>
         </div>
-        <div class="p-3">
-          {% if filter.qs.count == 1 %}
-            {{ filter.qs.count }} result.
-          {% else %}
-            {{ filter.qs.count }} results.
-          {% endif %}
-        </div>
-      {% if filter.qs %}
-        {% include 'includes/council-table.html' with councils=filter.qs %}
-      {% endif %}
+
     </div>
 </div>
 


### PR DESCRIPTION
Two small changes extracted from the promises branch because they're likely to be useful elsewhere.

1 - move the location of the council page filters to make it easier to expand them.
2 - split out some of the plans CSV processing code into a utils file so it can be used in other import processes.