### PR TITLE
fix issues with relative paths imports in scss for other app's styles

### DIFF
--- a/caps/static/scss/main.scss
+++ b/caps/static/scss/main.scss
@@ -2,50 +2,62 @@
 
 // A NOTE ABOUT FILE PATHS
 //
-// as of 1.7.0 django-pipeline compiles the project files to the static
-// location so we have to use full paths from the app location
+// django.contrib.staticfiles copies this file into the `STATIC_ROOT`
+// (along with any other files/directories defined in `STATICFILES_DIRS`)
+// and then django-pipeline compiles the Sass files from there.
+//
+// So imports in this file are relative to `<STATIC_ROOT>/sass/main.scss`,
+// not `/caps/static/scss/main.scss`.
+//
+// That’s why `@import "../bootstrap/<whatever>" works – because at the
+// point the Sass files are compiled, django.contrib.staticfiles has
+// already copied the Bootstrap sass files into `<STATIC_ROOT>/bootstrap/`.
+//
+// Note that this doesn't work on a dev thing with standard django-pipeline
+// due to this issue: https://github.com/jazzband/django-pipeline/issues/749
+// so we are using a fork with the patch from the above issue
 
 @import "variables";
 
-@import "../../../vendor/bootstrap/scss/functions";
-@import "../../../vendor/bootstrap/scss/variables";
-@import "../../../vendor/bootstrap/scss/mixins";
-@import "../../../vendor/bootstrap/scss/root";
-@import "../../../vendor/bootstrap/scss/reboot";
-@import "../../../vendor/bootstrap/scss/type";
-@import "../../../vendor/bootstrap/scss/images";
-@import "../../../vendor/bootstrap/scss/code";
-@import "../../../vendor/bootstrap/scss/grid";
-@import "../../../vendor/bootstrap/scss/tables";
-@import "../../../vendor/bootstrap/scss/forms";
-@import "../../../vendor/bootstrap/scss/buttons";
-@import "../../../vendor/bootstrap/scss/transitions";
-// @import "../../../vendor/bootstrap/scss/dropdown";
-// @import "../../../vendor/bootstrap/scss/button-group";
-// @import "../../../vendor/bootstrap/scss/input-group";
-// @import "../../../vendor/bootstrap/scss/custom-forms";
-@import "../../../vendor/bootstrap/scss/nav";
-@import "../../../vendor/bootstrap/scss/navbar";
-@import "../../../vendor/bootstrap/scss/card";
-// @import "../../../vendor/bootstrap/scss/breadcrumb";
-// @import "../../../vendor/bootstrap/scss/pagination";
-// @import "../../../vendor/bootstrap/scss/badge";
-// @import "../../../vendor/bootstrap/scss/jumbotron";
-// @import "../../../vendor/bootstrap/scss/alert";
-@import "../../../vendor/bootstrap/scss/progress";
-// @import "../../../vendor/bootstrap/scss/media";
-// @import "../../../vendor/bootstrap/scss/list-group";
-// @import "../../../vendor/bootstrap/scss/close";
-// @import "../../../vendor/bootstrap/scss/toasts";
-@import "../../../vendor/bootstrap/scss/modal";
-@import "../../../vendor/bootstrap/scss/tooltip";
-// @import "../../../vendor/bootstrap/scss/popover";
-// @import "../../../vendor/bootstrap/scss/carousel";
-@import "../../../vendor/bootstrap/scss/spinners";
-@import "../../../vendor/bootstrap/scss/utilities";
-@import "../../../vendor/bootstrap/scss/print";
+@import "../bootstrap/functions";
+@import "../bootstrap/variables";
+@import "../bootstrap/mixins";
+@import "../bootstrap/root";
+@import "../bootstrap/reboot";
+@import "../bootstrap/type";
+@import "../bootstrap/images";
+@import "../bootstrap/code";
+@import "../bootstrap/grid";
+@import "../bootstrap/tables";
+@import "../bootstrap/forms";
+@import "../bootstrap/buttons";
+@import "../bootstrap/transitions";
+// @import "../bootstrap/dropdown";
+// @import "../bootstrap/button-group";
+// @import "../bootstrap/input-group";
+// @import "../bootstrap/custom-forms";
+@import "../bootstrap/nav";
+@import "../bootstrap/navbar";
+@import "../bootstrap/card";
+// @import "../bootstrap/breadcrumb";
+// @import "../bootstrap/pagination";
+// @import "../bootstrap/badge";
+// @import "../bootstrap/jumbotron";
+// @import "../bootstrap/alert";
+@import "../bootstrap/progress";
+// @import "../bootstrap/media";
+// @import "../bootstrap/list-group";
+// @import "../bootstrap/close";
+// @import "../bootstrap/toasts";
+@import "../bootstrap/modal";
+@import "../bootstrap/tooltip";
+// @import "../bootstrap/popover";
+// @import "../bootstrap/carousel";
+@import "../bootstrap/spinners";
+@import "../bootstrap/utilities";
+@import "../bootstrap/print";
 
-@import "../../../vendor/chartjs/Chart";
+@import "../chartjs/Chart";
 
 @import "awesomplete";
 @import "equilateral-triangle";

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,8 +13,8 @@ django-haystack==3.0
 django-htmlmin==0.11.0
 django-import-export==2.0.2
 django-markitup==4.0.0
-django-pipeline==2.0.5
 djangorestframework==3.12.4
+-e git+https://github.com/mysociety/django-pipeline@c67514ae828f79454320a37b0aeb154c7359e19c#egg=django_pipeline
 -e git+https://github.com/mysociety/django-pipeline-csscompressor@6a88fde5045d68746f1c7ee816deda86615c5581#egg=django_pipeline_csscompressor
 et-xmlfile==1.0.1
 feedparser==5.2.1


### PR DESCRIPTION
Importing other apps styles is handled differently in live and dev
environments as the dev environment processes the non collected file and
live processes the collected file.

There is an existing ticket for this: https://github.com/jazzband/django-pipeline/issues/749
which has a PR. To fix this we've forked the fixed version and are using
that directly from github rather than pulling in an official package.