### PR TITLE
add council promises to the API

### DIFF
--- a/caps/api/serializers.py
+++ b/caps/api/serializers.py
@@ -10,6 +10,7 @@ class CouncilSerializer(serializers.HyperlinkedModelSerializer):
     carbon_reduction_commitment = serializers.BooleanField()
     carbon_neutral_date = serializers.IntegerField()
     carbon_reduction_statements = serializers.HyperlinkedIdentityField(view_name='council-commitments')
+    declared_emergency = serializers.DateField()
 
     class Meta:
         model = Council
@@ -25,6 +26,7 @@ class CouncilSerializer(serializers.HyperlinkedModelSerializer):
             'carbon_reduction_commitment',
             'carbon_neutral_date',
             'carbon_reduction_statements',
+            'declared_emergency',
         ]
 
     # we don't get a count where there aren't any plans so force this

--- a/caps/api/serializers.py
+++ b/caps/api/serializers.py
@@ -1,6 +1,5 @@
-from caps.models import Council, SavedSearch
+from caps.models import Council, SavedSearch, Promise
 from rest_framework import serializers
-
 
 class CouncilSerializer(serializers.HyperlinkedModelSerializer):
     url = serializers.URLField(source='get_absolute_url')
@@ -8,10 +7,49 @@ class CouncilSerializer(serializers.HyperlinkedModelSerializer):
     country = serializers.CharField(source='get_country_display')
     authority_type = serializers.CharField(source='get_authority_type_display')
     plans_last_update = serializers.DateField()
+    carbon_reduction_commitment = serializers.BooleanField()
+    carbon_neutral_date = serializers.IntegerField()
+    carbon_reduction_statements = serializers.HyperlinkedIdentityField(view_name='council-commitments')
 
     class Meta:
         model = Council
-        fields = ['name', 'url', 'website_url', 'gss_code', 'country', 'authority_type', 'plan_count', 'plans_last_update']
+        fields = [
+            'name',
+            'url',
+            'website_url',
+            'gss_code',
+            'country',
+            'authority_type',
+            'plan_count',
+            'plans_last_update',
+            'carbon_reduction_commitment',
+            'carbon_neutral_date',
+            'carbon_reduction_statements',
+        ]
+
+    # we don't get a count where there aren't any plans so force this
+    # to 0 rather than null
+    def to_representation(self, instance):
+        ret = super().to_representation(instance)
+        if ret['plan_count'] is None:
+            ret['plan_count'] = 0
+        return ret
+
+class PromiseSerializer(serializers.HyperlinkedModelSerializer):
+    scope = serializers.CharField(source='get_scope_display')
+
+    class Meta:
+        model = Promise
+        fields = [
+            'council',
+            'has_promise',
+            'target_year',
+            'scope',
+            'text',
+            'source',
+            'source_name',
+        ]
+
 
 class SearchTermSerializer(serializers.HyperlinkedModelSerializer):
     times_seen = serializers.IntegerField()

--- a/caps/api/serializers.py
+++ b/caps/api/serializers.py
@@ -1,5 +1,5 @@
 from caps.models import Council, SavedSearch, Promise
-from rest_framework import serializers
+from rest_framework import serializers, reverse
 
 class CouncilSerializer(serializers.HyperlinkedModelSerializer):
     url = serializers.URLField(source='get_absolute_url')
@@ -9,8 +9,11 @@ class CouncilSerializer(serializers.HyperlinkedModelSerializer):
     plans_last_update = serializers.DateField()
     carbon_reduction_commitment = serializers.BooleanField()
     carbon_neutral_date = serializers.IntegerField()
-    carbon_reduction_statements = serializers.HyperlinkedIdentityField(view_name='council-commitments')
     declared_emergency = serializers.DateField()
+    carbon_reduction_statements = serializers.HyperlinkedIdentityField(
+        view_name='council-commitments',
+        lookup_field='authority_code'
+    )
 
     class Meta:
         model = Council
@@ -21,6 +24,7 @@ class CouncilSerializer(serializers.HyperlinkedModelSerializer):
             'gss_code',
             'country',
             'authority_type',
+            'authority_code',
             'plan_count',
             'plans_last_update',
             'carbon_reduction_commitment',
@@ -38,6 +42,7 @@ class CouncilSerializer(serializers.HyperlinkedModelSerializer):
         return ret
 
 class PromiseSerializer(serializers.HyperlinkedModelSerializer):
+    council = serializers.SerializerMethodField()
     scope = serializers.CharField(source='get_scope_display')
 
     class Meta:
@@ -51,6 +56,14 @@ class PromiseSerializer(serializers.HyperlinkedModelSerializer):
             'source',
             'source_name',
         ]
+
+    def get_council(self, obj):
+        code = obj.council.authority_code
+        # do this is a string otherwise you get an array as the result
+        result = '{}'.format(
+            reverse.reverse('council-detail', args=[code], request=self.context['request']),
+        )
+        return result
 
 
 class SearchTermSerializer(serializers.HyperlinkedModelSerializer):

--- a/caps/api/views.py
+++ b/caps/api/views.py
@@ -50,6 +50,7 @@ class CouncilViewSet(viewsets.ReadOnlyModelViewSet):
     * carbon_reduction_commitment - True if the council has public commitments to reduce emissions
     * carbon_neutral_date - the earliest date for a carbon neutral target (null if no date)
     * carbon_neutral_commitments - link to list of commitments made by council
+    * declared_emergency - date, if any, council declared a climate emergency
     """
 
     # need to use subqueries otherwise the joins mean we get bad counts
@@ -59,6 +60,7 @@ class CouncilViewSet(viewsets.ReadOnlyModelViewSet):
         plan_count=Subquery(plans),
         carbon_reduction_commitment=Exists(promised),
         carbon_neutral_date=Min('promise__target_year'),
+        declared_emergency=Min('emergencydeclaration__date_declared'),
         plans_last_update=Max('plandocument__updated_at'),
     ).order_by('name')
 

--- a/caps/api/views.py
+++ b/caps/api/views.py
@@ -85,7 +85,7 @@ class CommitmentsViewSet(viewsets.ReadOnlyModelViewSet):
     * source - URL of the document the commitment comes from
     * source_name - name of the document the commitment comes from
     """
-    queryset = Promise.objects.order_by('council__name', 'target_year').all()
+    queryset = Promise.objects.order_by('council__name', 'target_year').select_related('council').all()
     serializer_class = PromiseSerializer
 
 class CouncilCommitmentsViewSet(viewsets.ReadOnlyModelViewSet):
@@ -108,7 +108,7 @@ class CouncilCommitmentsViewSet(viewsets.ReadOnlyModelViewSet):
     pagination_class = None
 
     def get_queryset(self):
-        return Promise.objects.filter(council_id=self.kwargs['pk']).order_by('target_year').all()
+        return Promise.objects.filter(council__authority_code=self.kwargs['authority_code']).select_related('council').order_by('target_year').all()
 
 class SearchTermViewSet(viewsets.ReadOnlyModelViewSet):
     """

--- a/caps/management/commands/postprocess.py
+++ b/caps/management/commands/postprocess.py
@@ -19,6 +19,14 @@ def remove_internal_data():
 
     df.to_csv(open(out_csv, "w"), index=False, header=True)
 
+    out_csv = join(settings.MEDIA_ROOT, 'data', settings.DECLARATIONS_CSV_NAME)
+    df = pd.read_csv(settings.DECLARATIONS_CSV)
+    df = df.drop(columns=[
+        'control_at_declaration', 'control_now', 'leader', 'proposer',
+    ])
+
+    df.to_csv(open(out_csv, "w"), index=False, header=True)
+
 def add_last_update():
     out_csv = join(settings.MEDIA_ROOT, 'data', settings.PROCESSED_CSV_NAME)
     df = pd.read_csv(out_csv)

--- a/caps/management/commands/postprocess.py
+++ b/caps/management/commands/postprocess.py
@@ -1,5 +1,6 @@
 # -*- coding: future_fstrings -*-
 from os.path import join, basename, splitext, isfile
+from shutil import copy
 import os
 import sys
 
@@ -32,6 +33,16 @@ def add_last_update():
 
     df.to_csv(open(out_csv, "w"), index=False, header=True)
 
+def copy_files_to_media():
+    files = [
+        settings.PROMISES_CSV
+    ]
+
+    for file in files:
+        file_name = basename(file)
+        dst = join(settings.MEDIA_ROOT, 'data', file_name)
+        copy(file, dst)
+
 
 
 class Command(BaseCommand):
@@ -49,3 +60,5 @@ class Command(BaseCommand):
         remove_internal_data()
         print("add last update to csv file")
         add_last_update()
+        print("copy files to media directory")
+        copy_files_to_media()

--- a/caps/models.py
+++ b/caps/models.py
@@ -114,6 +114,17 @@ class Council(models.Model):
         return descriptions_to_codes.get(country_entry.lower().strip())
 
     @classmethod
+    def authority_type_code(cls, authority_type):
+        """
+        Return an authority type code given a text description, or None if the description
+        isn't in the authority type choices
+        """
+        if pd.isnull(authority_type):
+            return None
+        descriptions_to_codes = dict((type.lower(), code) for code, type in Council.AUTHORITY_TYPE_CHOICES)
+        return descriptions_to_codes.get(authority_type.lower().strip())
+
+    @classmethod
     def percent_with_plan(cls):
         """
         Return the percentage of councils that have a plan document

--- a/caps/templates/about.html
+++ b/caps/templates/about.html
@@ -16,7 +16,7 @@
 
     <p>Links to council climate action plans were crowdsourced by an army of volunteers <a href="https://docs.google.com/spreadsheets/d/1tEnjJRaWsdXtCkMwA25-ZZ8D75zAY6c2GOOeUchZsnU/edit">in this spreadsheet</a>. If you find a plan document that we’ve missed, <a href="https://docs.google.com/document/d/1oGFkzhZkTCfEBUeJIdMb9aOfuqPoCHkUMTJxROsRRow/edit">read our guide</a> on what we consider a climate action plan and how to add one to our spreadsheet.</p>
 
-    <p>You can <a href="{{ MEDIA_URL }}data/plans/plans.zip">download a zip file of all the plans</a>. This includes a CSV file (plans.csv) with details and sources for all the included files, along with information like GSS codes to enable linking to other data. The <a href="{{ MEDIA_URL }}data/plans.csv">csv file</a> is also available separately.</p>
+    <p>You can <a href="{{ MEDIA_URL }}data/plans/plans.zip">download a zip file of all the plans</a>. This includes a CSV file (plans.csv) with details and sources for all the included files, along with information like GSS codes to enable linking to other data. The <a href="{{ MEDIA_URL }}data/plans.csv">csv file</a> is also available separately. We also make details of councils <a href="{{ MEDIA_URL }}data/declarations.csv">climate emergency declarations</a> and <a href="{{ MEDIA_URL }}data/promises.csv">carbon neutral commitments</a> available as CSV files.</p>
 
     <p>We also have <a href="{% url 'api-root' %}">an API</a> through which an increasing quantity of our data will be available.</p>
 

--- a/caps/tests/test_api.py
+++ b/caps/tests/test_api.py
@@ -131,6 +131,104 @@ class CouncilsAPITestCase(APITestCase):
             } ]
         )
 
+    def test_filtering(self):
+        Council.objects.create(name='West Borsetshire',
+                               slug='west-borsetshire',
+                               country=Council.ENGLAND,
+                               authority_type='UA',
+                               authority_code='WBS',
+                               gss_code='E14000112')
+
+        Council.objects.create(name='East Borsetshire',
+                               slug='east-borsetshire',
+                               country=Council.ENGLAND,
+                               authority_type='CTY',
+                               website_url="https://east-borsetshire.gov.uk",
+                               authority_code='EBS',
+                               gss_code='E14000113')
+
+        Council.objects.create(name='North Borsetshire',
+                               slug='north-borsetshire',
+                               country=Council.SCOTLAND,
+                               authority_type='MD',
+                               website_url="https://north-borsetshire.gov.uk",
+                               authority_code='NBS',
+                               gss_code='E14000114')
+
+        response = self.client.get('/api/councils/?authority_type=County Council')
+
+        self.assertEquals(json.loads(response.content),
+            [ {
+                'name': 'East Borsetshire',
+                'url': '/councils/east-borsetshire/',
+                'website_url': 'https://east-borsetshire.gov.uk',
+                'gss_code': 'E14000113',
+                'country': 'England',
+                'authority_type': 'County Council',
+                'authority_code': 'EBS',
+                'plan_count': 0,
+                'plans_last_update': None,
+                'carbon_neutral_date': None,
+                'carbon_reduction_commitment': False,
+                'carbon_reduction_statements': 'http://testserver/api/councils/EBS/commitments',
+                'declared_emergency': None,
+            } ]
+        )
+
+        response = self.client.get('/api/councils/?authority_type=County Council,Unitary Authority')
+
+        self.assertEquals(json.loads(response.content),
+            [ {
+                'name': 'East Borsetshire',
+                'url': '/councils/east-borsetshire/',
+                'website_url': 'https://east-borsetshire.gov.uk',
+                'gss_code': 'E14000113',
+                'country': 'England',
+                'authority_type': 'County Council',
+                'authority_code': 'EBS',
+                'plan_count': 0,
+                'plans_last_update': None,
+                'carbon_neutral_date': None,
+                'carbon_reduction_commitment': False,
+                'carbon_reduction_statements': 'http://testserver/api/councils/EBS/commitments',
+                'declared_emergency': None,
+            }, {
+                'name': 'West Borsetshire',
+                'url': '/councils/west-borsetshire/',
+                'website_url': '',
+                'gss_code': 'E14000112',
+                'country': 'England',
+                'authority_type': 'Unitary Authority',
+                'authority_code': 'WBS',
+                'plan_count': 0,
+                'plans_last_update': None,
+                'carbon_neutral_date': None,
+                'carbon_reduction_commitment': False,
+                'carbon_reduction_statements': 'http://testserver/api/councils/WBS/commitments',
+                'declared_emergency': None,
+            } ]
+        )
+
+        response = self.client.get('/api/councils/?country=Scotland')
+
+        self.assertEquals(json.loads(response.content),
+            [ {
+                'name': 'North Borsetshire',
+                'url': '/councils/north-borsetshire/',
+                'website_url': 'https://north-borsetshire.gov.uk',
+                'gss_code': 'E14000114',
+                'country': 'Scotland',
+                'authority_type': 'Metropolitan District',
+                'authority_code': 'NBS',
+                'plan_count': 0,
+                'plans_last_update': None,
+                'carbon_neutral_date': None,
+                'carbon_reduction_commitment': False,
+                'carbon_reduction_statements': 'http://testserver/api/councils/NBS/commitments',
+                'declared_emergency': None,
+            } ]
+        )
+
 class PromisesAPITest(APITestCase):
     def setUp(self):
         self.council_bors = Council.objects.create(name='Borsetshire',

--- a/caps/tests/test_api.py
+++ b/caps/tests/test_api.py
@@ -23,10 +23,11 @@ class CouncilsAPITestCase(APITestCase):
         # bit more readable
         self.assertEquals(json.loads(response.content),
             [ {
+                'authority_code': 'BOS',
                 'authority_type': '',
                 'carbon_neutral_date': None,
                 'carbon_reduction_commitment': False,
-                'carbon_reduction_statements': 'http://testserver/api/councils/1/commitments',
+                'carbon_reduction_statements': 'http://testserver/api/councils/BOS/commitments',
                 'declared_emergency': None,
                 'gss_code': 'E14000111',
                 'country': 'England',
@@ -50,10 +51,11 @@ class CouncilsAPITestCase(APITestCase):
 
         self.assertEquals(json.loads(response.content),
             [ {
+                'authority_code': 'BOS',
                 'authority_type': '',
                 'carbon_neutral_date': None,
                 'carbon_reduction_commitment': False,
-                'carbon_reduction_statements': 'http://testserver/api/councils/2/commitments',
+                'carbon_reduction_statements': 'http://testserver/api/councils/BOS/commitments',
                 'declared_emergency': None,
                 'gss_code': 'E14000111',
                 'country': 'England',
@@ -76,6 +78,7 @@ class CouncilsAPITestCase(APITestCase):
         Council.objects.create(name='East Borsetshire',
                                slug='east-borsetshire',
                                country=Council.ENGLAND,
+                               authority_type='CC',
                                website_url="https://east-borsetshire.gov.uk",
                                authority_code='EBS',
                                gss_code='E14000113')
@@ -90,11 +93,12 @@ class CouncilsAPITestCase(APITestCase):
                 'gss_code': 'E14000111',
                 'country': 'England',
                 'authority_type': '',
+                'authority_code': 'BOS',
                 'plan_count': 0,
                 'plans_last_update': None,
                 'carbon_neutral_date': None,
                 'carbon_reduction_commitment': False,
-                'carbon_reduction_statements': 'http://testserver/api/councils/3/commitments',
+                'carbon_reduction_statements': 'http://testserver/api/councils/BOS/commitments',
                 'declared_emergency': None,
             }, {
                 'name': 'East Borsetshire',
@@ -102,12 +106,13 @@ class CouncilsAPITestCase(APITestCase):
                 'website_url': 'https://east-borsetshire.gov.uk',
                 'gss_code': 'E14000113',
                 'country': 'England',
-                'authority_type': '',
+                'authority_type': 'City of London',
+                'authority_code': 'EBS',
                 'plan_count': 0,
                 'plans_last_update': None,
                 'carbon_neutral_date': None,
                 'carbon_reduction_commitment': False,
-                'carbon_reduction_statements': 'http://testserver/api/councils/5/commitments',
+                'carbon_reduction_statements': 'http://testserver/api/councils/EBS/commitments',
                 'declared_emergency': None,
             }, {
                 'name': 'West Borsetshire',
@@ -116,11 +121,12 @@ class CouncilsAPITestCase(APITestCase):
                 'gss_code': 'E14000112',
                 'country': 'England',
                 'authority_type': 'Unitary Authority',
+                'authority_code': 'WBS',
                 'plan_count': 0,
                 'plans_last_update': None,
                 'carbon_neutral_date': None,
                 'carbon_reduction_commitment': False,
-                'carbon_reduction_statements': 'http://testserver/api/councils/4/commitments',
+                'carbon_reduction_statements': 'http://testserver/api/councils/WBS/commitments',
                 'declared_emergency': None,
             } ]
         )
@@ -160,11 +166,12 @@ class PromisesAPITest(APITestCase):
                 'gss_code': 'E14000111',
                 'country': 'England',
                 'authority_type': '',
+                'authority_code': 'BOS',
                 'plan_count': 0,
                 'plans_last_update': None,
                 'carbon_neutral_date': 2035,
                 'carbon_reduction_commitment': True,
-                'carbon_reduction_statements': 'http://testserver/api/councils/6/commitments',
+                'carbon_reduction_statements': 'http://testserver/api/councils/BOS/commitments',
                 'declared_emergency': None
             }, {
                 'name': 'West Borsetshire',
@@ -173,19 +180,20 @@ class PromisesAPITest(APITestCase):
                 'gss_code': 'E14000112',
                 'country': 'England',
                 'authority_type': 'Unitary Authority',
+                'authority_code': 'WBS',
                 'plan_count': 0,
                 'plans_last_update': None,
                 'carbon_neutral_date': None,
                 'carbon_reduction_commitment': False,
-                'carbon_reduction_statements': 'http://testserver/api/councils/7/commitments',
+                'carbon_reduction_statements': 'http://testserver/api/councils/WBS/commitments',
                 'declared_emergency': None
             } ]
         )
 
-        response = self.client.get('/api/councils/6/commitments')
+        response = self.client.get('/api/councils/BOS/commitments')
         self.assertEquals(json.loads(response.content),
             [ {
-                'council': 'http://testserver/api/councils/6/',
+                'council': 'http://testserver/api/councils/BOS/',
                 'has_promise': True,
                 'target_year': 2035,
                 'scope': 'Council only',

--- a/caps/tests/test_api.py
+++ b/caps/tests/test_api.py
@@ -27,6 +27,7 @@ class CouncilsAPITestCase(APITestCase):
                 'carbon_neutral_date': None,
                 'carbon_reduction_commitment': False,
                 'carbon_reduction_statements': 'http://testserver/api/councils/1/commitments',
+                'declared_emergency': None,
                 'gss_code': 'E14000111',
                 'country': 'England',
                 'name': 'Borsetshire',
@@ -53,6 +54,7 @@ class CouncilsAPITestCase(APITestCase):
                 'carbon_neutral_date': None,
                 'carbon_reduction_commitment': False,
                 'carbon_reduction_statements': 'http://testserver/api/councils/2/commitments',
+                'declared_emergency': None,
                 'gss_code': 'E14000111',
                 'country': 'England',
                 'name': 'Borsetshire',
@@ -93,6 +95,7 @@ class CouncilsAPITestCase(APITestCase):
                 'carbon_neutral_date': None,
                 'carbon_reduction_commitment': False,
                 'carbon_reduction_statements': 'http://testserver/api/councils/3/commitments',
+                'declared_emergency': None,
             }, {
                 'name': 'East Borsetshire',
                 'url': '/councils/east-borsetshire/',
@@ -105,6 +108,7 @@ class CouncilsAPITestCase(APITestCase):
                 'carbon_neutral_date': None,
                 'carbon_reduction_commitment': False,
                 'carbon_reduction_statements': 'http://testserver/api/councils/5/commitments',
+                'declared_emergency': None,
             }, {
                 'name': 'West Borsetshire',
                 'url': '/councils/west-borsetshire/',
@@ -117,6 +121,7 @@ class CouncilsAPITestCase(APITestCase):
                 'carbon_neutral_date': None,
                 'carbon_reduction_commitment': False,
                 'carbon_reduction_statements': 'http://testserver/api/councils/4/commitments',
+                'declared_emergency': None,
             } ]
         )
 
@@ -159,7 +164,8 @@ class PromisesAPITest(APITestCase):
                 'plans_last_update': None,
                 'carbon_neutral_date': 2035,
                 'carbon_reduction_commitment': True,
-                'carbon_reduction_statements': 'http://testserver/api/councils/6/commitments'
+                'carbon_reduction_statements': 'http://testserver/api/councils/6/commitments',
+                'declared_emergency': None
             }, {
                 'name': 'West Borsetshire',
                 'url': '/councils/west-borsetshire/',
@@ -171,7 +177,8 @@ class PromisesAPITest(APITestCase):
                 'plans_last_update': None,
                 'carbon_neutral_date': None,
                 'carbon_reduction_commitment': False,
-                'carbon_reduction_statements': 'http://testserver/api/councils/7/commitments'
+                'carbon_reduction_statements': 'http://testserver/api/councils/7/commitments',
+                'declared_emergency': None
             } ]
         )
 

--- a/caps/urls.py
+++ b/caps/urls.py
@@ -8,7 +8,7 @@ import caps.api.views as api_views
 from caps.api import routers
 
 router = routers.Router()
-router.register(r'councils', api_views.CouncilViewSet)
+router.register(r'councils', api_views.CouncilViewSet, basename='council')
 router.register(r'searchterms', api_views.SearchTermViewSet)
 router.register(r'commitments', api_views.CommitmentsViewSet)
 

--- a/caps/urls.py
+++ b/caps/urls.py
@@ -24,6 +24,6 @@ urlpatterns = [
     path('style/', views.StyleView.as_view(), name='style'),
     path('admin/', admin.site.urls),
     path('api/', include(router.urls)),
-    path('api/councils/<int:pk>/commitments', api_views.CouncilCommitmentsViewSet.as_view({'get': 'list'}), name='council-commitments')
+    path('api/councils/<str:authority_code>/commitments', api_views.CouncilCommitmentsViewSet.as_view({'get': 'list'}), name='council-commitments')
 
 ]

--- a/caps/urls.py
+++ b/caps/urls.py
@@ -10,6 +10,7 @@ from caps.api import routers
 router = routers.Router()
 router.register(r'councils', api_views.CouncilViewSet)
 router.register(r'searchterms', api_views.SearchTermViewSet)
+router.register(r'commitments', api_views.CommitmentsViewSet)
 
 urlpatterns = [
     path('', views.HomePageView.as_view(), name='home'),
@@ -23,5 +24,6 @@ urlpatterns = [
     path('style/', views.StyleView.as_view(), name='style'),
     path('admin/', admin.site.urls),
     path('api/', include(router.urls)),
+    path('api/councils/<int:pk>/commitments', api_views.CouncilCommitmentsViewSet.as_view({'get': 'list'}), name='council-commitments')
 
 ]


### PR DESCRIPTION
Adds link to list of promises to each council, plus an end point for
a list of all promises

This also adds in filtering for the council endpoint and moves to using the authority code to look up individual council details.