### PR TITLE
Track clicks on Net Zero Local Hero landing page

### DIFF
--- a/caps/static/js/main.js
+++ b/caps/static/js/main.js
@@ -272,3 +272,31 @@ var trackEvent = function(eventName, params) {
 $('.details-accordion').on('click', function(){
     $(this).siblings('.details-accordion[open]').removeAttr('open');
 });
+
+$('.nzlh-landing-page').on('click', 'a[href]', function(e){
+    var href = $(e.currentTarget).attr('href');
+
+    var callback;
+    if (
+        e.ctrlKey ||
+        e.shiftKey ||
+        e.metaKey ||
+        (e.button && e.button == 1) // middle mouse button
+    ){
+        callback = function() {};
+    } else {
+        e.preventDefault();
+        callback = function() {
+            if (href) {
+                window.location.href = href;
+            }
+        };
+    }
+
+    var text = $(e.currentTarget).text().replace(/\s+/g, ' ').replace(/(^\s+|\s+$)/g, '') || $(e.currentTarget).find('[src]').attr('src');
+
+    trackEvent('nzlh_landing_page_click', {
+        'link_text': text,
+        'destination': href
+    }).done(callback);
+});

--- a/caps/templates/net_zero_local_hero.html
+++ b/caps/templates/net_zero_local_hero.html
@@ -2,6 +2,8 @@
 
 {% load static %}
 
+{% block bodyclass %}nzlh-landing-page{% endblock %}
+
 {% block content %}
 
 <div class="card ceuk-card mb-gutter">


### PR DESCRIPTION
More tracking on the Net Zero Local Hero landing page.

Records a Google Analytics event whenever any `a[href]` on the landing page is clicked (_anywhere_ on the page, including the header and nav). Sends Google the text content of the link itself (or the image filename, if it’s a link containing only an image) and the URL that the user is about to go to.

Doesn’t track form submissions (like the postcode search form) because that’s a bit harder.

Not very pretty code, but good enough to temporarily measure activity on the landing page over COP26.

/cc @MyfanwyNixon