### PR TITLE
move information about data to its own page

### DIFF
--- a/caps/templates/about.html
+++ b/caps/templates/about.html
@@ -14,13 +14,7 @@
 
     <h2 class="mt-5">Data sources</h2>
 
-    <p>Links to council climate action plans were crowdsourced by an army of volunteers <a href="https://docs.google.com/spreadsheets/d/1tEnjJRaWsdXtCkMwA25-ZZ8D75zAY6c2GOOeUchZsnU/edit">in this spreadsheet</a>. If you find a plan document that we’ve missed, <a href="https://docs.google.com/document/d/1oGFkzhZkTCfEBUeJIdMb9aOfuqPoCHkUMTJxROsRRow/edit">read our guide</a> on what we consider a climate action plan and how to add one to our spreadsheet.</p>
-
-    <p>You can <a href="{{ MEDIA_URL }}data/plans/plans.zip">download a zip file of all the plans</a>. This includes a CSV file (plans.csv) with details and sources for all the included files, along with information like GSS codes to enable linking to other data. The <a href="{{ MEDIA_URL }}data/plans.csv">csv file</a> is also available separately. We also make details of councils <a href="{{ MEDIA_URL }}data/declarations.csv">climate emergency declarations</a> and <a href="{{ MEDIA_URL }}data/promises.csv">carbon neutral commitments</a> available as CSV files.</p>
-
-    <p>We also have <a href="{% url 'api-root' %}">an API</a> through which an increasing quantity of our data will be available.</p>
-
-    <p>Local authority CO<sub>2</sub> emissions estimates are <a href="https://www.gov.uk/government/statistics/uk-local-authority-and-regional-carbon-dioxide-emissions-national-statistics-2005-to-2019">collated by the Department of Business, Energy &amp; Skills</a>.</p>
+    <p>There is more about our both the source of our data and how you can access it on the <a href="{% url 'about_data' %}">Our data</a> page.
 
     <h2 class="mt-5">Got feedback? Want to contribute?</h2>
 

--- a/caps/templates/about_data.html
+++ b/caps/templates/about_data.html
@@ -1,0 +1,54 @@
+{% extends "base.html" %}
+
+{% block content %}
+
+<div style="max-width: 40em">
+
+    <h1 class="mb-4">Our data</h1>
+
+    <p>Much of our data is crowdsourced by an army of volunteers filling in Google spreadsheets. This is then combined with some standard data to enable it to be matched up across sources.</a>
+
+    <p>Links to council climate action plans were crowdsourced <a href="https://docs.google.com/spreadsheets/d/1tEnjJRaWsdXtCkMwA25-ZZ8D75zAY6c2GOOeUchZsnU/edit">in this spreadsheet</a>. If you find a plan document that we’ve missed, <a href="https://docs.google.com/document/d/1oGFkzhZkTCfEBUeJIdMb9aOfuqPoCHkUMTJxROsRRow/edit">read our guide</a> on what we consider a climate action plan and how to add one to our spreadsheet.</p>
+
+    <p>Council climate emergency declarations and Net zero commitments were largely collated by CEUK staff.</p>
+
+    <p>Local authority CO<sub>2</sub> emissions estimates are <a href="https://www.gov.uk/government/statistics/uk-local-authority-and-regional-carbon-dioxide-emissions-national-statistics-2005-to-2019">collated by the Department of Business, Energy &amp; Skills</a>.</p>
+
+    <h2 class="mt-5">Council Plans</h2>
+
+    <p>You can <a href="{{ MEDIA_URL }}data/plans/plans.zip">download a zip file of all the plans</a>. As well as the PDFs, or HTML pages, of the plans, this includes a CSV file (plans.csv) with details and sources for all the included files, along with information like GSS codes to enable linking to other data. The CSV file is available separately, see below for details.</p>
+
+    <h2 class="mt-5">API</h2>
+
+    <p>We have <a href="{% url 'api-root' %}">an API</a> through which an increasing quantity of our data will be available. The API page includes a full description of the data available.</p>
+
+    <h2 class="mt-5">CSV files</h2>
+
+    <p>If you need to use our data in your own spreadsheets then the following data is available to download as CSV files:<p>
+
+    <ul>
+        <li><a href="{{ MEDIA_URL }}data/plans.csv">Council plans</a>.</li>
+        <li><a href="{{ MEDIA_URL }}data/promises.csv">Council net zero commitments</a>.</li>
+        <li><a href="{{ MEDIA_URL }}data/declarations.csv">Council climate emergency declarations</a>.</li>
+    </ul>
+
+    <p>While most of the details in the plans CSV are hopefully fairly straightforward there are a few which require further explanations:</p>
+
+    <ul>
+        <li><b>last_update</b> - This is the date we last updated any information about the plan. It is not the date the plan was last updated.</li>
+        <li><b>url</b> - The URL where the plan was fetched.</li>
+        <li><b>plan_path</b> - This is the path to download the plan from our website.</li>
+        <li><b>scope</b> - Council only means the plan only deals with the council's operations. Whole area means the plan covers non council activities within council boundaries as well.</li>
+    </ul>
+
+    <p>All CSV files include the council GSS code, and a three letter council code you can use with the API, to enable matching data across files, and with other sources.</p>
+
+    <h2 class="mt-5">Got feedback? Want to contribute?</h2>
+
+    <p>Take <a href="{{settings.SURVEY_URL}}">our user survey</a> to give us feedback about the kind of groups using the service.</p>
+
+    <p>If you have more detailed feedback or questions, email us at <a href="mailto:climate-councils@mysociety.org">climate-councils@mysociety.org</a>.</p>
+
+</div>
+
+{% endblock %}

--- a/caps/urls.py
+++ b/caps/urls.py
@@ -19,6 +19,7 @@ urlpatterns = [
     path('councils/', views.CouncilListView.as_view(), name='council_list'),
     path('location/', views.LocationResultsView.as_view(), name='location_results'),
     path('about/', views.AboutView.as_view(), name='about'),
+    path('about/data/', views.AboutDataView.as_view(), name='about_data'),
     path('ajax/mailchimp_email', views.MailchimpView.as_view(), name='mailchimp_hook'),
     path('net-zero-local-hero/', views.NetZeroLocalHeroView.as_view(), name='net_zero_local_hero'),
     path('style/', views.StyleView.as_view(), name='style'),

--- a/caps/views.py
+++ b/caps/views.py
@@ -182,6 +182,13 @@ class AboutView(TemplateView):
         'page_title': 'About'
     }
 
+class AboutDataView(TemplateView):
+
+    template_name = "about_data.html"
+    extra_context = {
+        'page_title': 'Our data'
+    }
+
 
 class MailchimpView(View):
     """


### PR DESCRIPTION
Mostly so it doesn't overwhelm the about page and also so as we expand
the data we can put more information here.