### PR TITLE
Make sure even “other” scope promises have a heading

### DIFF
--- a/caps/templates/council_detail.html
+++ b/caps/templates/council_detail.html
@@ -38,9 +38,16 @@
               {% endif %}
               {% if promises %}
                   {% for promise in promises %}
+                    <h3 class="h6 mt-4">
                       {% if promise.get_scope %}
-                      <h3 class="h6 mt-4">{{ promise.get_scope|capfirst }} pledge {% if promise.target_year %}for {{ promise.target_year }}{% endif %}</h3>
+                        {{ promise.get_scope|capfirst }} pledge
+                      {% else %}
+                        Climate pledge
                       {% endif %}
+                      {% if promise.target_year %}
+                        for {{ promise.target_year }}
+                      {% endif %}
+                    </h3>
                     <blockquote class="blockquote">
                         <p class="mb-0">“{{ promise.text }}”</p>
                         <footer class="blockquote-footer"><cite title="{{ promise.source_name }}"><a href="{{ promise.source }}">{{ promise.source_name }}</a></cite></footer>


### PR DESCRIPTION
Fixes a bug introduced in #163 that caused promises (“pledges”) with a scope of “other” to display on the council detail page without a heading above them, meaning they crashed into the line above.

**Before:**

![Screenshot 2021-11-16 at 14 24 00](https://user-images.githubusercontent.com/739624/142003036-fe655f43-3385-46bb-9a52-f123ba8ce5a9.png)

**After:**

![Screenshot 2021-11-16 at 14 23 41](https://user-images.githubusercontent.com/739624/142003061-662ee13c-1a75-45f5-b8ff-b83c57685444.png)
