### PR TITLE
Add an exact search option to the search form

### DIFF
--- a/caps/forms.py
+++ b/caps/forms.py
@@ -1,8 +1,11 @@
-from django.forms import CharField
+from django.forms import CharField, BooleanField
 from haystack.forms import SearchForm
+from haystack.query import SearchQuerySet
+from haystack.inputs import Exact
 
 class HighlightedSearchForm(SearchForm):
     council_name=CharField(required=False)
+    exact=BooleanField(required=False)
 
     def search(self):
         kwargs = {
@@ -11,7 +14,17 @@ class HighlightedSearchForm(SearchForm):
             'hl.fragsize': 400,
             'hl.snippets': 3
         }
-        sqs = super(HighlightedSearchForm, self).search()
+        sqs = self.no_query_found()
+
+        # use the text_exact field in solr which doesn't stem
+        if self.cleaned_data['q'] and self.cleaned_data['exact'] is True:
+            query = self.cleaned_data['q']
+            kwargs['hl.fl'] = 'text_exact'
+            sqs = SearchQuerySet().filter(text_exact=Exact(query))
+            if self.load_all:
+                sqs = sqs.load_all()
+        else:
+            sqs = super(HighlightedSearchForm, self).search()
 
         if self.cleaned_data['council_name']:
             # narrow makes use of fq rather than q

--- a/caps/templates/includes/text-search-result.html
+++ b/caps/templates/includes/text-search-result.html
@@ -8,5 +8,8 @@
       {% for text in result.highlighted.text %}
         <p>…{% autoescape off %}{{ text }}{% endautoescape %}…</p>
       {% endfor %}
+      {% for text in result.highlighted.text_exact %}
+        <p>…{% autoescape off %}{{ text }}{% endautoescape %}…</p>
+      {% endfor %}
     </div>
 </div>

--- a/caps/templates/search_results.html
+++ b/caps/templates/search_results.html
@@ -15,6 +15,12 @@
                         <input type="text" class="form-control" name="q" id="q" value="{{ query|default_if_none:'' }}">
                     </div>
                     <div class="form-group">
+                    <div class="form-check">
+                        <input type="checkbox" class="form-check-input" name="exact" id="exact"{% if form.exact.value is True %} checked{% endif %}>
+                        <label class="form-check-label" for="exact">Exact match</label>
+                    </div>
+                    </div>
+                    <div class="form-group">
                         <label for="council_name" class="d-flex flex-wrap flex-row-reverse">
                             <span class="text-muted">(Optional)</span>
                             <span class="mr-auto">Council name contains</span>


### PR DESCRIPTION
This required an extra solr field with unstemmed text which will increase the size of the index but as it's never going to get that large I think this is a reasonable trade off. You can't just do an Exact on a stemmed field as it still stems.

Fixes #168