### PR TITLE
M1 build fixups

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       - POSTGRES_DB=${REPOSITORY_DB_NAME:-caps}
 
   solr:
-    image: solr:6
+    image: solr:6.5
     volumes:
       - solr_data:/opt/solr/server/solr/mycores
       - ./conf/schema.xml:/opt/solr/server/solr/configsets/basic_configs/conf/schema.xml

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ jdcal==1.4.1
 libsass==0.12.3
 Markdown==2.6.8
 MarkupPy==1.14
-numpy==1.18.5
+numpy==1.21.4
 odfpy==1.4.1
 olefile==0.44
 openpyxl==3.0.9


### PR DESCRIPTION
Couple of very small fixups to permit a fresh clone on an Apple M1 to run and build the app container.

Note the issues with Solr, perhaps a wider discussion on what to do about upgrading this dependency is in order.

For numpy, I simply remove the version constraint then built and updated the requirements file with the version selected.