### PR TITLE
Changed datasources to point to new repo

### DIFF
--- a/caps/dataframe/la.py
+++ b/caps/dataframe/la.py
@@ -9,9 +9,9 @@ import string
 import pandas as pd
 import numpy as np
 
-la_lookup_url = "https://raw.githubusercontent.com/ajparsons/uk_local_authority_names_and_codes/master/uk_local_authorities.csv"
-name_lookup_url = "https://raw.githubusercontent.com/ajparsons/uk_local_authority_names_and_codes/master/lookup_name_to_registry.csv"
-gss_code = "https://raw.githubusercontent.com/ajparsons/uk_local_authority_names_and_codes/master/lookup_gss_to_registry.csv"
+la_lookup_url = "https://raw.githubusercontent.com/mysociety/uk_local_authority_names_and_codes/main/data/uk_local_authorities.csv"
+name_lookup_url = "https://raw.githubusercontent.com/mysociety/uk_local_authority_names_and_codes/main/data/lookup_name_to_registry.csv"
+gss_code = "https://raw.githubusercontent.com/mysociety/uk_local_authority_names_and_codes/main/data/lookup_gss_to_registry.csv"
 
 
 @lru_cache
@@ -162,7 +162,7 @@ class LAPDAccessor(object):
                    columns: Optional[List[str]] = None,
                    aggfunc="sum",
                    weight_on: Optional[str] = None,
-                   comparison_column: str = "replaced_by",
+                   comparison_column: str = "replaced-by",
                    upgrade_absent: bool = True) -> pd.DataFrame:
         """
         If given values by primary authority, this may be former authorities.

--- a/caps/import_utils.py
+++ b/caps/import_utils.py
@@ -12,28 +12,26 @@ import ssl
 ssl._create_default_https_context = ssl._create_unverified_context
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
-AUTHORITY_MAPPING_URL = 'https://raw.githubusercontent.com/crowbot/uk_local_authority_names_and_codes/master/lookup_name_to_registry.csv'
+
+AUTHORITY_MAPPING_URL = 'https://raw.githubusercontent.com/mysociety/uk_local_authority_names_and_codes/main/data/lookup_name_to_registry.csv'
 AUTHORITY_MAPPING_NAME = 'lookup_name_to_registry.csv'
 AUTHORITY_MAPPING = join(settings.DATA_DIR, AUTHORITY_MAPPING_NAME)
 
-AUTHORITY_DATA_URL = 'https://raw.githubusercontent.com/crowbot/uk_local_authority_names_and_codes/master/uk_local_authorities.csv'
+AUTHORITY_DATA_URL = 'https://raw.githubusercontent.com/mysociety/uk_local_authority_names_and_codes/main/data/uk_local_authorities.csv'
 AUTHORITY_DATA_NAME = 'uk_local_authorities.csv'
 AUTHORITY_DATA = join(settings.DATA_DIR, AUTHORITY_DATA_NAME)
 
-COMBINED_AUTHORITY_DATA_URL = 'http://geoportal1-ons.opendata.arcgis.com/datasets/43d30f924b29452b881e1820dcf897f9_0.csv'
-COMBINED_AUTHORITY_DATA_NAME = 'combined_authorities.csv'
-COMBINED_AUTHORITY_DATA = join(settings.DATA_DIR, COMBINED_AUTHORITY_DATA_NAME)
 
 def get_data_files():
 
     data_files = [(AUTHORITY_MAPPING_URL, AUTHORITY_MAPPING),
-                  (AUTHORITY_DATA_URL, AUTHORITY_DATA),
-                  (COMBINED_AUTHORITY_DATA_URL, COMBINED_AUTHORITY_DATA)]
+                  (AUTHORITY_DATA_URL, AUTHORITY_DATA)]
 
     for (source, destination) in data_files:
         r = requests.get(source)
         with open(destination, 'wb') as outfile:
             outfile.write(r.content)
+
 
 def add_authority_codes(filename):
     mapping_df = pd.read_csv(AUTHORITY_MAPPING)
@@ -51,12 +49,14 @@ def add_authority_codes(filename):
     for index, row in plans_df.iterrows():
         council = row['council'].lower()
 
-        name_versions = [council, council.replace('council', '').strip(), council.replace('- unitary', '').replace('(unitary)', '').strip()]
+        name_versions = [council, council.replace('council', '').strip(
+        ), council.replace('- unitary', '').replace('(unitary)', '').strip()]
         for version in name_versions:
             if version in names_to_codes:
                 plans_df.at[index, 'authority_code'] = names_to_codes[version]
                 break
     plans_df.to_csv(open(filename, "w"), index=False, header=True)
+
 
 def add_gss_codes(filename):
 
@@ -69,59 +69,46 @@ def add_gss_codes(filename):
     for index, row in plans_df.iterrows():
         authority_code = row['authority_code']
         if not pd.isnull(authority_code):
-            authority_match = authority_df[authority_df['local-authority-code'] == authority_code]
-            plans_df.at[index, 'gss_code'] = authority_match['gss-code'].values[0]
+            authority_match = authority_df[authority_df['local-authority-code']
+                                           == authority_code]
+            plans_df.at[index,
+                        'gss_code'] = authority_match['gss-code'].values[0]
 
     plans_df.to_csv(open(filename, "w"), index=False, header=True)
+
 
 def add_extra_authority_info(filename):
 
     authority_df = pd.read_csv(AUTHORITY_DATA)
     plans_df = pd.read_csv(filename)
 
-    rows = len(plans_df['council'])
-    plans_df['authority_type'] = pd.Series([None] * rows, index=plans_df.index)
-    plans_df['wdtk_id'] = pd.Series([None] * rows, index=plans_df.index)
-    plans_df['mapit_area_code'] = pd.Series([None] * rows, index=plans_df.index)
-    plans_df['country'] = pd.Series([None] * rows, index=plans_df.index)
-    plans_df['gss_code'] = pd.Series([None] * rows, index=plans_df.index)
+    df = authority_df[["local-authority-code", "local-authority-type",
+                       "wdtk-id", "mapit-area-code", "nation", "gss-code"]]
 
-    for index, row in plans_df.iterrows():
-        authority_code = row['authority_code']
-        if not pd.isnull(authority_code):
-            authority_match = authority_df[authority_df['local-authority-code'] == authority_code]
-            country = None
-            country = authority_match['nation'].values[0]
-            plans_df.at[index, 'authority_type'] = authority_match['local-authority-type'].values[0]
-            plans_df.at[index, 'wdtk_id'] = authority_match['wdtk_ids'].values[0]
-            plans_df.at[index, 'mapit_area_code'] = authority_match['mapit_area_code'].values[0]
-            plans_df.at[index, 'country'] = country
-            plans_df.at[index, 'gss_code'] = authority_match['gss-code'].values[0]
+    df = df.rename(columns={"local-authority-code": "authority_code",
+                            "local-authority-type": "authority_type",
+                            "wdtk-id": "wdtk_id",
+                            "mapit-area-code": "mapit_area_code",
+                            "nation": "country",
+                            "gss-code": "gss_code"
+                            })
 
-            # All authorities in Wales, Scotland and Northern Ireland are unitary
-            if country in ['Wales', 'Scotland', 'Northern Ireland']:
-                plans_df.at[index, 'authority_type'] = 'UA'
-    plans_df.to_csv(open(filename, "w"), index=False, header=True)
+    # the info sheet may contain updated version of columns previously
+    # loaded to sheet, need to drop them before the merge
+    # ignore errors in case columns are not present
+    columns_to_drop = [x for x in df.columns if x != "authority_code"]
+    plans_df = plans_df.drop(columns=columns_to_drop, errors="ignore")
 
-def add_combined_authority_gss_codes(filename):
-    plans_df = pd.read_csv(filename)
-    combined_authority_df = pd.read_csv(COMBINED_AUTHORITY_DATA)
+    # merge two dataframes using the authority_code as the common reference
+    df = plans_df.merge(df, on="authority_code", how="left")
 
-    aliases = {'newcastle upon tyne, north tyneside and northumberland combined authority': 'north of tyne'}
+    is_non_english = df["country"].isin(['Wales',
+                                         'Scotland',
+                                         'Northern Ireland'])
+    df.loc[is_non_english, "authority_type"] = "UA"
 
-    names_to_codes = {}
-    for index, row in combined_authority_df.iterrows():
-        names_to_codes[row['CAUTH19NM'].lower()] = row['CAUTH19CD']
-    for index, row in plans_df.iterrows():
-        council = row['council'].lower()
-        if row['authority_type'] == 'COMB':
-            name_versions = [council, council.replace('combined authority', '').strip()]
-            if council in aliases:
-                name_versions.append(aliases[council])
-            for version in name_versions:
-                if version in names_to_codes:
-                    plans_df.at[index, 'gss_code'] = names_to_codes[version]
-                    break
+    # treat greater london authority as combined
+    is_strategic = df["authority_type"] == "SRA"
+    df.loc[is_strategic, "authority_type"] = "COMB"
 
-    plans_df.to_csv(open(filename, "w"), index=False, header=True)
-
+    df.to_csv(filename, index=False, header=True)

--- a/caps/management/commands/add_authority_codes.py
+++ b/caps/management/commands/add_authority_codes.py
@@ -9,32 +9,20 @@ from django.core.management.base import BaseCommand, CommandError
 from django.conf import settings
 
 
-from caps.import_utils import get_data_files, add_extra_authority_info, add_authority_codes, add_combined_authority_gss_codes
+from caps.import_utils import (get_data_files, add_extra_authority_info,
+                               add_authority_codes)
 
 
-def add_missing_authorities():
+def check_missing_authorities():
     plans_df = pd.read_csv(settings.PROCESSED_CSV)
-    manual_codes = { 'West Yorkshire Combined Authority': ['WYCA', 'COMB', '52339', 'England'],
-                     'North East Combined Authority': ['NECA', 'COMB', '52428', 'England'],
-                     'Newcastle Upon Tyne, North Tyneside and Northumberland Combined Authority': ['NTCA', 'COMB', '91532', 'England']
-                    }
 
-    missing_councils = []
-    for index, row in plans_df[plans_df['authority_code'].isnull()].iterrows():
-        council = row['council']
-        authority_code = row['authority_code']
+    mask = plans_df['authority_code'].isnull()
+    missing_councils = plans_df["council"][mask].tolist()
 
-        if council in manual_codes:
-            plans_df.at[index, 'authority_code'] = manual_codes[council][0]
-            plans_df.at[index, 'authority_type'] = manual_codes[council][1]
-            plans_df.at[index, 'wdtk_id'] = manual_codes[council][2]
-            plans_df.at[index, 'country'] = manual_codes[council][3]
-        else:
-            missing_councils.append(council)
-
-    plans_df.to_csv(open(settings.PROCESSED_CSV, "w"), index=False, header=True)
     print(f"Councils without authority codes {len(missing_councils)}")
-    print(missing_councils)
+    if len(missing_councils):
+        print(missing_councils)
+
 
 class Command(BaseCommand):
     help = 'Adds authority codes to the csv of plans'
@@ -46,7 +34,5 @@ class Command(BaseCommand):
         add_authority_codes(settings.PROCESSED_CSV)
         print('adding authority info')
         add_extra_authority_info(settings.PROCESSED_CSV)
-        print('adding missing authorities')
-        add_missing_authorities()
-        print('adding combined authority codes')
-        add_combined_authority_gss_codes(settings.PROCESSED_CSV)
+        print('check for missing authorities')
+        check_missing_authorities()


### PR DESCRIPTION
We now have a [repo](https://github.com/mysociety/uk_local_authority_names_and_codes) with a good source of truth for local authority information including combined authorities. 

This PR removes and updates references to older versions of this lookup, and added information that was being manually patched back into the main repo. 

This seems to setup from scratch ok, but @struan might have some other ideas about edge cases that are worth testing. 