### PR TITLE
Search form can search for similar councils

### DIFF
--- a/caps/models.py
+++ b/caps/models.py
@@ -722,8 +722,11 @@ class ComparisonType(models.Model):
         "emissions": "Emissions",
         "geographic_distance": "Nearby",
         "imd": "IMD",
-        "ruc": " Rural/Urban",
+        "ruc": "Rural/Urban",
     }
+
+    def __str__(self):
+        return self.name
 
     def markdown_desc(self):
         return markdown.markdown(self.desc)

--- a/caps/templates/search_results.html
+++ b/caps/templates/search_results.html
@@ -7,19 +7,32 @@
 
         <div class="card ceuk-card mb-gutter position-sticky" style="top: 1rem;">
             <div class="card-body">
-                <h1 class="mb-3">Search inside plans</h1>
-
+                
+              {% if form.similar_council.value %}
+                <h1 class="mb-3">Search councils similar to {{form.cleaned_data.similar_council.name}}</h1>
+              {% else %}
+                  <h1 class="mb-3">Search inside plans</h1>
+              {% endif %}
                 <form action="{% url 'search_results' %}" class="mb-n3">
                     <div class="form-group">
                         <label for="q">Search phrase</label>
                         <input type="text" class="form-control" name="q" id="q" value="{{ query|default_if_none:'' }}">
                     </div>
                     <div class="form-group">
-                    <div class="form-check">
-                        <input type="checkbox" class="form-check-input" name="exact" id="exact"{% if form.exact.value is True %} checked{% endif %}>
-                        <label class="form-check-label" for="exact">Exact match</label>
+                        <div class="form-check">
+                            <input type="checkbox" class="form-check-input" name="exact" id="exact"{% if form.exact.value is True %} checked{% endif %}>
+                            <label class="form-check-label" for="exact">Exact match</label>
+                        </div>
                     </div>
-                    </div>
+                  {% if form.similar_council.value %}
+                    <input type="hidden" name="similar_council" id="similar_council" value="{{ form.similar_council.value|default_if_none:'' }}">
+                  {% endif %}
+                  {% if form.similar_type.value %}
+                    <label for="similar_type" class="d-flex flex-wrap flex-row-reverse">
+                      <span class="mr-auto">Similarity type</span>
+                    </label>
+                    {{form.similar_type}}
+                  {% else %}
                     <div class="form-group">
                         <label for="council_name" class="d-flex flex-wrap flex-row-reverse">
                             <span class="text-muted">(Optional)</span>
@@ -27,6 +40,7 @@
                         </label>
                         <input type="text" class="form-control" name="council_name" id="council_name" value="{{ form.council_name.value|default_if_none:'' }}">
                     </div>
+                  {% endif %}
                     <div class="form-group">
                         <button type="submit" class="btn btn-primary btn-block mt-4 d-flex align-items-center justify-content-center">
                             {% include 'icons/search.html' with classes="mr-2" %}


### PR DESCRIPTION
When following the link from the council page the name is displayed and passed back through. The comparison type is given in a dropdown.

Addresses part of https://github.com/mysociety/caps/issues/219, where the search link for similar types isn't actually usable. 

If not following the link from the council page, these options aren't visible. 

![image](https://user-images.githubusercontent.com/8157058/148580676-0bc3b27f-2e69-4cb8-bc47-6fd1ee7432cd.png)
