### PR TITLE
use authority type on front page

### DIFF
--- a/scoring/templates/scoring/home.html
+++ b/scoring/templates/scoring/home.html
@@ -29,7 +29,7 @@
             <div class="table-header mb-4 align-items-end">
                 <div>
                     <h3 class="underline">
-                        <span>single tier</span>
+                        <span>{{ authority_type_label }}</span>
                         <span>·</span>
                         <span>urban</span>
                     </h3>

--- a/scoring/templates/scoring/includes/advanced-filter.html
+++ b/scoring/templates/scoring/includes/advanced-filter.html
@@ -6,6 +6,7 @@ data-popup-trigger="one" type="button">Advanced filters</button>
         <button class="close-icon popup-modal__close" type="button"></button>
     </div>
     <form>
+        {% if authority_type == 'single' %}
         <div class="criteria-group-wrapper">
             <button class="h5 btn-open-div" type="button">
                 Nation
@@ -25,6 +26,7 @@ data-popup-trigger="one" type="button">Advanced filters</button>
                 </div>
             </div>
         </div>
+        {% endif %}
 
         <div class="criteria-group-wrapper">
             <button class="h5 btn-open-div" type="button">Urbanization</button>
@@ -84,6 +86,7 @@ data-popup-trigger="one" type="button">Advanced filters</button>
             </div>
         </div>
 
+        {% if authority_type != 'combined' and authority_type != 'northern-ireland' %}
         <div class="criteria-group-wrapper">
             <button class="h5 btn-open-div" type="button">
                 Index of multiple deprivation
@@ -103,6 +106,7 @@ data-popup-trigger="one" type="button">Advanced filters</button>
                 </div>
             </div>
         </div>
+        {% endif %}
 
         <div class="criteria-group-wrapper">
             <button class="h5 btn-open-div" type="button">

--- a/scoring/templates/scoring/includes/main-filter.html
+++ b/scoring/templates/scoring/includes/main-filter.html
@@ -5,10 +5,10 @@
     
     <h6 class="mb-3">filter the table by type of council</h6>
     <div class="type-council-option-wrapper">
-        <a class="radio-btn is--with-label active" href="{% url 'scoring' 'single' %}">Single Tier</a>
-        <a class="radio-btn is--with-label" href="{% url 'scoring' 'district' %}">District</a>
-        <a class="radio-btn is--with-label" href="{% url 'scoring' 'county' %}">County</a>
-        <a class="radio-btn is--with-label" href="{% url 'scoring' 'combined' %}">Combined</a>
-        <a class="radio-btn is--with-label" href="{% url 'scoring' 'northern-ireland' %}">Northern Ireland</a>
+        <a class="radio-btn is--with-label{% if authority_type == 'single' %} active{% endif %}" href="{% url 'scoring' 'single' %}">Single Tier</a>
+        <a class="radio-btn is--with-label{% if authority_type == 'district' %} active{% endif %}" href="{% url 'scoring' 'district' %}">District</a>
+        <a class="radio-btn is--with-label{% if authority_type == 'county' %} active{% endif %}" href="{% url 'scoring' 'county' %}">County</a>
+        <a class="radio-btn is--with-label{% if authority_type == 'combined' %} active{% endif %}" href="{% url 'scoring' 'combined' %}">Combined</a>
+        <a class="radio-btn is--with-label{% if authority_type == 'northern-ireland' %} active{% endif %}" href="{% url 'scoring' 'northern-ireland' %}">Northern Ireland</a>
     </div>
 </form>

--- a/scoring/views.py
+++ b/scoring/views.py
@@ -61,6 +61,7 @@ class HomePageView(ListView):
 
         authority_type = self.get_authority_type()
         context['authority_type'] = authority_type['slug']
+        context['authority_type_label'] = authority_type['name']
 
         context['form'] = form
         context['council_data'] = councils


### PR DESCRIPTION
Highlight which authority type we are filtering by, and also change advanced filter options appropriately.