### PR TITLE
Better holding page for Scorecards site

### DIFF
--- a/scoring/templates/scoring/base.html
+++ b/scoring/templates/scoring/base.html
@@ -7,7 +7,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>SCORING</title>
+    <title>Council Climate Plan Scorecards</title>
 
     {% stylesheet 'scoring' %}
 </head>

--- a/scoring/templates/scoring/home.html
+++ b/scoring/templates/scoring/home.html
@@ -1,8 +1,18 @@
 {% extends "scoring/base.html" %}
+
+{% block bodyclass %}py-5 text-center{% endblock %}
+
 {% block content %}
 
-    <h1>Council Climate Scorecards</h1>
+<div class="container">
+    <p class="mb-4 text-muted">Coming soon</p>
 
-    <p>holding page</p>
+    <h1 class="mb-4">Council Climate Plan Scorecards</h1>
+
+    <p class="mb-4 text-muted">
+        From <a href="https://www.climateemergency.uk">Climate Emergency UK</a>.
+        Built by <a href="https://www.mysociety.org">mySociety</a>.
+    </p>
+</div>
 
 {% endblock %}


### PR DESCRIPTION
From this:

![Screenshot 2022-01-14 at 08-42-00 SCORING](https://user-images.githubusercontent.com/739624/149483046-b1ee2e3b-9c7a-48b7-90a8-fdb94105577f.png)

To this:

![Screenshot 2022-01-14 at 08-41-34 SCORING](https://user-images.githubusercontent.com/739624/149483085-ea669ec8-0615-4b03-a4ae-c176841754d8.png)

@MyfanwyNixon I take it we’re ok with this wording?