### PR TITLE
Unique council loading

### DIFF
--- a/caps/management/commands/add_council_websites.py
+++ b/caps/management/commands/add_council_websites.py
@@ -46,6 +46,8 @@ def get_england_and_wales():
     rows = body.find_all("tr")
     for row in rows:
         link = row.find("th").find("a")
+        if link is None:
+            continue
         council = link.text
         website_url = link["href"]
         twitter_link = row.find("td").find(href=re.compile(r"twitter.com"))

--- a/caps/management/commands/import_plans.py
+++ b/caps/management/commands/import_plans.py
@@ -201,13 +201,15 @@ class Command(BaseCommand):
             twitter_url = PlanDocument.char_from_text(row["twitter_url"])
             twitter_name = PlanDocument.char_from_text(row["twitter_name"])
             council, created = Council.objects.get_or_create(
-                name=row["council"],
-                slug=PlanDocument.council_slug(row["council"]),
                 authority_code=PlanDocument.char_from_text(row["authority_code"]),
-                authority_type=PlanDocument.char_from_text(row["authority_type"]),
-                gss_code=PlanDocument.char_from_text(row["gss_code"]),
                 country=Council.country_code(row["country"]),
                 defaults={
+                    "authority_type": PlanDocument.char_from_text(
+                        row["authority_type"]
+                    ),
+                    "name": row["council"],
+                    "slug": PlanDocument.council_slug(row["council"]),
+                    "gss_code": PlanDocument.char_from_text(row["gss_code"]),
                     "whatdotheyknow_id": PlanDocument.integer_from_text(row["wdtk_id"]),
                     "mapit_area_code": PlanDocument.char_from_text(
                         row["mapit_area_code"]
@@ -220,6 +222,25 @@ class Command(BaseCommand):
 
             # check the council things that might change
             changed = False
+
+            if (
+                PlanDocument.char_from_text(row["authority_type"])
+                != council.authority_type
+            ):
+                council.authority_type = PlanDocument.char_from_text(
+                    row["authority_type"]
+                )
+                changed = True
+
+            if row["council"] != council.name:
+                council.name = row["council"]
+                council.slug = PlanDocument.council_slug(row["council"])
+                changed = True
+
+            if PlanDocument.char_from_text(row["gss_code"]) != council.gss_code:
+                council.gss_code = PlanDocument.char_from_text(row["gss_code"])
+                changed = True
+
             if council_url != "" and council.website_url != council_url:
                 council.website_url = council_url
                 changed = True


### PR DESCRIPTION
Small fix: Fixed a current error when importing from council websites.

Bigger fix:  https://github.com/mysociety/caps/issues/216 requires changing a council's name, but currently that would lead to duplicate entries. This changes the council import process to just check for uniqueness on code and country. 