### PR TITLE
Set scorecard data to v1

### DIFF
--- a/proj/settings.py
+++ b/proj/settings.py
@@ -152,7 +152,7 @@ PLAN_YEAR = 2021
 PLAN_SCORECARD_DATASET_DETAILS = {
     "org": "mysociety",
     "repo": "climate_scorecard_data",
-    "tag": "0.10.0",
+    "tag": "1.0.0",
     "private": True,
 }
 


### PR DESCRIPTION
Change scorecard dataset to v1 - this should be the final version.

The dataset passes automated tests, and included some additional plans identified as missing.