### PR TITLE
Clarify that emissions data is within scope of influence

### DIFF
--- a/caps/templates/council_detail.html
+++ b/caps/templates/council_detail.html
@@ -249,7 +249,12 @@
             </div>
             <div class="card-body">
                 {% include 'charting/includes/chart-display.html' with chart=chart_collection.multi_emissions %}
-                <p class="text-muted mb-0"><small>Latest CO<sub>2</sub> estimates from <a href="https://www.gov.uk/government/statistics/uk-local-authority-and-regional-carbon-dioxide-emissions-national-statistics-2005-to-2019">the Department of Business, Energy &amp; Industrial Strategy</a>. County and combined authority data combined from constituent authorities.</small></p>
+                <p class="text-muted text-smaller mt-4 mb-0">
+                    Data from <a href="https://www.gov.uk/government/statistics/uk-local-authority-and-regional-carbon-dioxide-emissions-national-statistics-2005-to-2019">the Department of Business, Energy &amp; Industrial Strategy</a> “subset dataset”, representing carbon dioxide emissions within the scope of influence of local luthorities.
+                  {% if council.authority_type == 'CTY' or council.authority_type == 'COMB' %}
+                    Data has been combined from constituent local authorities.
+                  {% endif %}
+                </p>
 
             </div>
         </div>


### PR DESCRIPTION
Fixes #65 by reusing the BEIS wording that their “subset dataset” shows emissions “within the scope of influence of local authorities”.

Also, we now only show the "data combined" wording on County and Combined Authority pages, where it makes sense. And I’ve added a bit more margin, and tighter line spacing, to the entire message, to make it easier to read.

<img width="797" alt="Screenshot 2022-02-03 at 08 47 02" src="https://user-images.githubusercontent.com/739624/152310233-3ab7c1b6-1a24-42e2-aceb-6a9a76d9264c.png">

