### PR TITLE
Minor text fixes for Climate League about pages

### DIFF
--- a/scoring/templates/scoring/how-to-use-the-scorecards.html
+++ b/scoring/templates/scoring/how-to-use-the-scorecards.html
@@ -20,6 +20,7 @@
                 <h3 class="mb-4">How to use the Council Climate Plan Scorecards for climate action in your area.</h3>
                 <p>The <a href="{% url 'home' %}">Council Climate Plan Scorecards</a> let you see, at a glance, how your own council’s plan performs in comparison to the plans of other councils across the UK.</p>
                 <p>Based on common themes we saw when marking council Climate Action plans we have written a short summary, <a href="https://drive.google.com/file/d/1IcqQFwcKcz0XcxKRu9h-g3Zj8TsbyhuI/view">‘10 ways to improve your Council’s Climate Action Plan’</a>. This covers 10 things that councils can do to improve their Climate Action Plans based on our Scorecards.</p>
+                <p><a href="https://drive.google.com/file/d/1IcqQFwcKcz0XcxKRu9h-g3Zj8TsbyhuI/view" class="d-inline-block btn btn-blue is--light my-4"><strong>Download:</strong> Top 10 policy document</a></p>
                 <p>But once you’ve checked that out, you might be wondering what to do with this information. That’s quite understandable — the path from data to action isn’t always clear! So with that in mind we’ve gathered together some ways in which you, as residents and community groups, can use this data to bring about meaningful change.</p>
                 <div class="alert alert-warning mt-4 mb-0" role="alert">
                     <span>If you’re a Councillor or Officer <a href="#councillor">click here</a> for guidance on how to use the Scorecards within your council for change</span>
@@ -158,7 +159,7 @@
                     </li>
 
                     <li>
-                        <p><strong>Join a local campaign group</strong> You could take a look at groups listed on <a href="https://takeclimateaction.uk/join">Friends of the earth Climate Action Group Map</a>, or with <a href="https://www.campaigncc.org/local.shtml">Campaign Against Climate Change</a>, on <a href="https://climatenetwork.org/">Climate Network</a> (some groups might appear on multiple maps!) or find or start your own group locally.</p>
+                        <p><strong>Join a local campaign group</strong> You could take a look at groups listed on <a href="https://friendsoftheearth.uk/take-action/join-group-near-you">Friends of the Earth Climate Action Group Map</a>, or with <a href="https://www.campaigncc.org/local.shtml">Campaign Against Climate Change</a>, on <a href="https://climatenetwork.org/">Climate Network</a> (some groups might appear on multiple maps!) or find or start your own group locally.</p>
                         <div class="bubble is--blue mb-4">
                             <h5 class="mb-2">Why?</h5>
                             <p class="mb-0">Acting alone can be daunting, and it's easier to shape an actionable request based on the data when you have a group to discuss it with.</p>
@@ -211,7 +212,7 @@
                             </div>
                         </li>
     
-                        <li> }
+                        <li>
                             <p><strong>Run an event or meeting based around the league</strong> Online or in person.</p>
                             <div class="bubble is--blue mb-4">
                                 <h5 class="mb-2">Why?</h5>
@@ -240,6 +241,7 @@
                     <p>The Scorecards score each council’s Climate Action Plan on 28 questions across 9 sections, following <a href="https://www.climateemergency.uk/blog/climate-action-plan-checklist/">Climate Emergency UK’s checklist</a></p>
                     <p>This scoring can only represent what has been captured within the councils’ public plans; not every action they have taken — although the published plans do tend to cover the majority of a council’s climate activity.</p>
                     <p>Don’t forget to check out our <a href="https://drive.google.com/file/d/1IcqQFwcKcz0XcxKRu9h-g3Zj8TsbyhuI/view">‘Top 10 ways to Improve your Climate Action Plan’</a> summary document, which is written in response to some of the common themes we noticed in Council Climate Action Plans and how they could be improved.</p>
+                    <p><a href="https://drive.google.com/file/d/1IcqQFwcKcz0XcxKRu9h-g3Zj8TsbyhuI/view" class="d-inline-block btn btn-blue is--light my-4"><strong>Download:</strong> Top 10 policy document</a></p>
                     <p>Here are some helpful tips on how best to understand this data and use it for meaningful improvement to your council’s planned activity.</p>
                     <ul class="mb-4">
                         <li>Take time to <strong>understand the</strong> <a href="{% url 'methodology' %}">methodology</a> and what exactly the markers were looking for in each question. </li>

--- a/scoring/templates/scoring/methodology.html
+++ b/scoring/templates/scoring/methodology.html
@@ -434,7 +434,7 @@
                 <h4 class="mb-3">Climate Scorecards filter</h4>
                 <div style="max-width:550px">
                     <p>There are five ‘leagues’. Filters are ways of subdividing leagues further. Not all filters apply to all leagues (league too small, doesn’t make conceptual sense to divide), the same filter may have different groupings in different leagues (population bandings are different to reflect different population of different kinds of council)</p>
-                    <p><strong>Data is in a private <a href="https://github.com/mysociety/climate_league_filter_datasets">repo</a></strong></p>
+                    <p><a href="https://github.com/mysociety/climate_league_filter_datasets">Download the source code that constructs the five ‘leagues’</a></p>
 
                     <h5>Index of multiple deprivation</h5>
                     <p>For two leagues (non-metropolitan districts, and single-tier), there is an index of multiple deprivation filters. This divides councils in each league into five quintiles, based on the multiple-deprivation ranking of a council in the group.</p>
@@ -468,7 +468,7 @@
 
         <div id="scoring-system" class="container medium">
             <h3 class="mb-3">Scoring system</h3>
-            <p style="max-width:550px">The scoring system consists of: <strong>9 sections</strong>, comprising <strong>27 questions</strong> which together contain <strong>73 sub-points</strong>.</p>
+            <p style="max-width:550px">The scoring system consists of: <strong>9 sections</strong>, comprising <strong>28 questions</strong> which together contain <strong>73 sub-points</strong>.</p>
             <p style="max-width:550px"><strong>78 marks</strong> are available for all councils, with the exception of County Councils and Combined Authorities where <strong>76 marks</strong> are available as question 11 does not apply.</p>
             <p class="mb-4" style="max-width:550px">There are more marks than there are sub-points because some questions are worth more than 1 point.</p>
             <div class="sub-topic mb-4">


### PR DESCRIPTION
* Replace "Data is in a private repo" text on Methodology page with a   link to the repo.
* Replace "27" (questions scored) on Methodology page with "28".
* Add a more prominent "Download the Top 10 policy document" button to the How To Use page.
* New link for the "Friends of the Earth Climate Action Group Map".
* Remove errant "}" character on How To Use page.

Fixes #325.