### PR TITLE
Remove Kent councils from Suffolk section of Scorecards Methodology

### DIFF
--- a/scoring/templates/scoring/methodology.html
+++ b/scoring/templates/scoring/methodology.html
@@ -600,13 +600,6 @@
                             <li>East Suffolk Council</li>
                             <li>Ipswich Borough Council</li>
                             <li>West Suffolk Council</li>
-                            <li>Folkestone and Hythe District Council</li>
-                            <li>Gravesham Borough Council</li>
-                            <li>Maidstone Borough Council</li>
-                            <li>Swale District Council</li>
-                            <li>Thanet District Council</li>
-                            <li>Tonbridge and Malling Borough Council</li>
-                            <li>Tunbridge Wells Borough Council</li>
                         </ul>
 
                         <h5>Surrey</h5>


### PR DESCRIPTION
This one should have been added to #325! Oh well.