### PR TITLE
Recalculate emissions for lower tier

### DIFF
--- a/caps/management/commands/import_emissions_data.py
+++ b/caps/management/commands/import_emissions_data.py
@@ -137,7 +137,7 @@ def import_emissions_data() -> None:
 
         # need to recreate because cannot be calculated from sum
 
-        for hdf in [county_df, combined_df]:
+        for hdf in [df, county_df, combined_df]:
             # both total emissions and population are stored in 1000s, so this keeps to tons
             hdf["Per Capita Emissions"] = hdf["Total Emissions"] / hdf["Population"]
             hdf["Emissions per km2"] = hdf["Total Emissions"] / hdf["Area"]


### PR DESCRIPTION
I've fixed this error before for upper tiers where the calculation of the per person and per area emissions statistics were wrong, but missed the same applies for new unitary councils.

The `to_modern()` process sums together the calculated values, but we weren't then re-calculating the derived values like we are for county/combined. 

Slight tweak to one line, and then `script/manage import_emissions_data --all` needs to be run.

Before:

![image](https://user-images.githubusercontent.com/8157058/156375927-680731d7-0fa7-4caa-8f30-3658eeafd290.png)

After:

![image](https://user-images.githubusercontent.com/8157058/156375944-c3caed6f-ced6-4c06-81df-1b0dc3f6539d.png)
