### PR TITLE
add filter for capitalising document titles

### DIFF
--- a/caps/templates/caps/council_detail.html
+++ b/caps/templates/caps/council_detail.html
@@ -88,9 +88,9 @@
                       {% endif %}
                         <div>
                             {% if plandocument.title %}
-                            <strong class="d-block">{{ plandocument.title|title }}</strong>
+                            <strong class="d-block">{{ plandocument.title|document_title }}</strong>
                             {% else %}
-                            <strong class="d-block">{{ council.name }} {{ plandocument.get_document_type|title }}</strong>
+                            <strong class="d-block">{{ council.name }} {{ plandocument.get_document_type|document_title }}</strong>
                             {% endif %}
                             <p class="d-inline-block text-muted mb-0">
                                 {% if plandocument.title %}

--- a/caps/templatetags/caps_templatetags.py
+++ b/caps/templatetags/caps_templatetags.py
@@ -1,5 +1,7 @@
 import re
 
+from string import capwords
+
 from django import template
 from django.template.defaultfilters import stringfilter
 
@@ -16,3 +18,14 @@ def domain_human(value):
 @stringfilter
 def url_human(value):
     return re.sub(r"^(https?:[/][/])?(www[.])?(.*)", r"\3", value)
+
+
+@register.filter
+@stringfilter
+def document_title(value):
+    """
+    The standard title filter regards apostrophes as a word boundary which
+    means you end up with things like "Aberdeen'S", so use capwords which
+    is a much better match for our use case.
+    """
+    return capwords(value)


### PR DESCRIPTION
The built in title filter capitalises after apostrophes which is a won't
fix issue (https://code.djangoproject.com/ticket/22323) so add our own
using string.capwords() which is better suited for plan document titles.