### PR TITLE
use extract file contents to index documents

### DIFF
--- a/caps/management/commands/import_plans.py
+++ b/caps/management/commands/import_plans.py
@@ -332,7 +332,6 @@ class Command(BaseCommand):
             "notes": char_from_text(row["notes"]),
             "file_type": char_from_text(row["file_type"]),
             "charset": char_from_text(row["charset"]),
-            "text": char_from_text(row["text"]),
             "start_year": start_year,
             "end_year": end_year,
             "date_last_found": date_from_text(row["date_retrieved"]),

--- a/caps/search_indexes.py
+++ b/caps/search_indexes.py
@@ -1,5 +1,6 @@
 from haystack import indexes
 from caps.models import PlanDocument
+from django.utils.html import strip_tags
 
 
 class PlanDocumentIndex(indexes.SearchIndex, indexes.Indexable):
@@ -17,3 +18,10 @@ class PlanDocumentIndex(indexes.SearchIndex, indexes.Indexable):
 
     def prepare_council_name(self, document):
         return document.council.name
+
+    def prepare_text(self, document):
+        file = document.file.open()
+        extracted_data = self.get_backend().extract_file_contents(file)
+
+        # data is converted to html as part of the extraction
+        return strip_tags(extracted_data["contents"])

--- a/script/trial_update
+++ b/script/trial_update
@@ -14,5 +14,4 @@ cd `dirname $0`/..
 "$(dirname "$0")/manage" preprocess
 "$(dirname "$0")/manage" add_authority_codes
 "$(dirname "$0")/manage" add_council_websites
-"$(dirname "$0")/manage" add_text
 "$(dirname "$0")/manage" import_plans "$@"

--- a/script/update
+++ b/script/update
@@ -10,7 +10,6 @@ cd `dirname $0`/..
 "$(dirname "$0")/manage" preprocess  "$@"
 "$(dirname "$0")/manage" add_authority_codes
 "$(dirname "$0")/manage" add_council_websites
-"$(dirname "$0")/manage" add_text "$@"
 "$(dirname "$0")/manage" import_plans --confirm_changes
 "$(dirname "$0")/manage" fetch_and_process_promises
 "$(dirname "$0")/manage" import_promises

--- a/templates/plandocument_text_index.txt
+++ b/templates/plandocument_text_index.txt
@@ -1,1 +1,1 @@
-{{ object.text }}
+{{ object.text|striptags }}


### PR DESCRIPTION
This is a Solr specific thing that relies on Solr's
ExtractingResourceHandler to parse structured files - see
https://django-haystack.readthedocs.io/en/master/rich_content_extraction.html

Means we should be indexing word documents etc as well.

For #129