### PR TITLE
Changed layout "Climate Documents" card

### DIFF
--- a/caps/static/caps/scss/backgrounds.scss
+++ b/caps/static/caps/scss/backgrounds.scss
@@ -5,3 +5,9 @@
 .bg-orange-gradient {
     background-image: linear-gradient(45deg, $color-ceuk-red, $color-ceuk-orange) !important;
 }
+
+@each $name, $color in $theme-colors {
+    .bg-#{$name}-light {
+        background-color: rgba($color, 0.05) !important;
+    }
+}

--- a/caps/static/caps/scss/ceuk-card.scss
+++ b/caps/static/caps/scss/ceuk-card.scss
@@ -97,5 +97,15 @@ $ceuk-card-colors: (
         .card-footer {
             background-color: rgba($color, 0.05);
         }
+
+        .card-body.is-emphasised-section {
+            background-color: rgba($color, 0.05);
+        }
+    }
+}
+
+@each $name, $color in $ceuk-card-colors {
+    .card--#{$name} {
+        background-color: rgba($color, 0.05) !important;
     }
 }

--- a/caps/static/caps/scss/ceuk-card.scss
+++ b/caps/static/caps/scss/ceuk-card.scss
@@ -97,15 +97,5 @@ $ceuk-card-colors: (
         .card-footer {
             background-color: rgba($color, 0.05);
         }
-
-        .card-body.is-emphasised-section {
-            background-color: rgba($color, 0.05);
-        }
-    }
-}
-
-@each $name, $color in $ceuk-card-colors {
-    .card--#{$name} {
-        background-color: rgba($color, 0.05) !important;
     }
 }

--- a/caps/templates/council_detail.html
+++ b/caps/templates/council_detail.html
@@ -79,7 +79,7 @@
             </div>
 
             {% if council.plandocument_set.all %}
-            <div class="card-body is-emphasised-section">
+            <div class="card-body bg-red-light">
                 <form action="{% url 'search_results' %}" data-show-interstitial class="form-row flex-wrap align-items-center">
                     <div class="col-auto flex-shrink-1 flex-grow-1" style="max-width: 450px">
                         <input type="text" class="form-control form-control-sm" name="q" id="search-this-councils-documents" value="{{ q|default_if_none:'' }}" placeholder="Search inside these documents">
@@ -130,7 +130,7 @@
                   {% endfor %}
                 </div>
             </div>
-            <div class="card-footer card--yellow">
+            <div class="card-footer bg-yellow-light">
                 <p class="mb-0"><strong>Do you know about an updated action plan?</strong></p>
                 <small class="mb-0">
                   If you think there is a more up to date Action Plan than the one listed on this page then please <a href="{{ feedback_form_url }}?usp=pp_url&entry.393810903={{ council.name }}">fill in this form</a> to let us know.

--- a/caps/templates/council_detail.html
+++ b/caps/templates/council_detail.html
@@ -82,7 +82,8 @@
             <div class="card-body bg-red-light">
                 <form action="{% url 'search_results' %}" data-show-interstitial class="form-row flex-wrap align-items-center">
                     <div class="col-auto flex-shrink-1 flex-grow-1" style="max-width: 450px">
-                        <input type="text" class="form-control form-control-sm" name="q" id="search-this-councils-documents" value="{{ q|default_if_none:'' }}" placeholder="Search inside these documents">
+                        <label for="search-this-councils-documents" class="sr-only">Search inside these documents</label>
+                        <input type="search" class="form-control form-control-sm" name="q" id="search-this-councils-documents" value="{{ q|default_if_none:'' }}" placeholder="Search inside these documents">
                         <input type="hidden" name="council_name" id="council_name" value="&quot;{{ council.name }}&quot;">
                     </div>
                     <div class="col-auto flex-shrink-0 d-flex">

--- a/caps/templates/council_detail.html
+++ b/caps/templates/council_detail.html
@@ -131,9 +131,9 @@
                 </div>
             </div>
             <div class="card-footer bg-yellow-light">
-                <p class="mb-0"><strong>Do you know about an updated action plan?</strong></p>
+                <p class="mb-0"><strong>Are these plans out of date?</strong></p>
                 <small class="mb-0">
-                  If you think there is a more up to date Action Plan than the one listed on this page then please <a href="{{ feedback_form_url }}?usp=pp_url&entry.393810903={{ council.name }}">fill in this form</a> to let us know.
+                  <a href="{{ feedback_form_url }}?usp=pp_url&entry.393810903={{ council.name }}">Fill in this form</a> to let us know where to find the latest plans from this council.
                 </small>
           </div>
         </div>

--- a/caps/templates/council_detail.html
+++ b/caps/templates/council_detail.html
@@ -77,6 +77,24 @@
                 <small class="text-muted line-height-1">Last update: {{ last_updated.last_update }}</small>
               {% endif %}
             </div>
+
+            {% if council.plandocument_set.all %}
+            <div class="card-body is-emphasised-section">
+                <form action="{% url 'search_results' %}" data-show-interstitial class="form-row flex-wrap align-items-center">
+                    <div class="col-auto flex-shrink-1 flex-grow-1" style="max-width: 450px">
+                        <input type="text" class="form-control form-control-sm" name="q" id="search-this-councils-documents" value="{{ q|default_if_none:'' }}" placeholder="Search inside these documents">
+                        <input type="hidden" name="council_name" id="council_name" value="&quot;{{ council.name }}&quot;">
+                    </div>
+                    <div class="col-auto flex-shrink-0 d-flex">
+                        <button type="submit" class="btn btn-purple btn-sm d-flex align-items-center">
+                            {% include 'icons/search.html' with role='presentation' %}
+                            <span class="ml-2">Search</span>
+                        </button>
+                    </div>
+                </form>
+            </div>
+            {% endif %}
+
             <div class="card-body">
                 <div class="mb-n3">
                   {% for plandocument in council.plandocument_set.all %}
@@ -112,23 +130,12 @@
                   {% endfor %}
                 </div>
             </div>
-          {% if council.plandocument_set.all %}
-            <div class="card-footer">
-                <form action="{% url 'search_results' %}" data-show-interstitial class="form-row flex-wrap align-items-center">
-                    <label for="search-this-councils-documents" class="col-12 col-lg-auto font-weight-bold mr-3 mb-2 mb-lg-0">Search inside these documents</label>
-                    <div class="col-auto flex-shrink-1 flex-grow-1">
-                        <input type="text" class="form-control form-control-sm" name="q" id="search-this-councils-documents" value="{{ q|default_if_none:'' }}">
-                        <input type="hidden" name="council_name" id="council_name" value="&quot;{{ council.name }}&quot;">
-                    </div>
-                    <div class="col-auto flex-shrink-0 d-flex">
-                        <button type="submit" class="btn btn-purple btn-sm d-flex align-items-center">
-                            {% include 'icons/search.html' with role='presentation' %}
-                            <span class="ml-2">Search</span>
-                        </button>
-                    </div>
-                </form>
-            </div>
-          {% endif %}
+            <div class="card-footer card--yellow">
+                <p class="mb-0"><strong>Do you know about an updated action plan?</strong></p>
+                <small class="mb-0">
+                  If you think there is a more up to date Action Plan than the one listed on this page then please <a href="{{ feedback_form_url }}?usp=pp_url&entry.393810903={{ council.name }}">fill in this form</a> to let us know.
+                </small>
+          </div>
         </div>
 
       {% if not scoring_hidden %}
@@ -438,17 +445,6 @@
                     <dd>Discover climate groups in this area, data about {{ council.name }}’s climate performance, and actions you can take.</dd>
                   {% endif %}
                 </dl>
-            </div>
-        </div>
-
-        <div class="card ceuk-card ceuk-card--muted ceuk-card--pink mb-gutter">
-            <div class="card-header">
-                <h2>Do you know about an updated action plan?</h2>
-            </div>
-            <div class="card-body">
-                <p class="mb-0 mt-n1">
-                If you think there is a more up to date Action Plan than the one listed on this page then please <a href="{{ feedback_form_url }}?usp=pp_url&entry.393810903={{ council.name }}">fill in this form</a> to let us know.
-                </p>
             </div>
         </div>
 


### PR DESCRIPTION
I moved the search bar to the top and replaced the label with a placeholder instead. I think the council page is quite busy at the moment, there are a lot of elements that draw attention, such as links and elements with colours, so I thought about economising and getting rid of the label.

I put the google form message at the bottom of the "Climate documents". Same reason as before, I wouldn't use h2 or make the message pop up that much. Give it enough visibility, so users know it is there without making it look like the most important part.

<img width="783" alt="Screenshot 2022-05-17 at 08 30 36" src="https://user-images.githubusercontent.com/13790153/168754622-ed19e32e-f387-4f7d-9583-c5d3f57e87e0.png">

