### PR TITLE
Improved council page accessibility (colour contrast)

### DIFF
--- a/caps/static/caps/scss/variables.scss
+++ b/caps/static/caps/scss/variables.scss
@@ -1,12 +1,12 @@
-$color-ceuk-blue: #00aeee;
+$color-ceuk-blue: #0277D1;
 $color-ceuk-navy: #005cab;
-$color-ceuk-purple: #7360eb;
+$color-ceuk-purple: #4e38de;
 $color-ceuk-pink: #d92b85;
 $color-ceuk-red: #e11d21;
 $color-ceuk-orange: #f29e1a;
 $color-ceuk-yellow: #ffd80b;
-$color-ceuk-green: #28cf6b;
-$color-ceuk-cyan: #54d9e2;
+$color-ceuk-green: #18964a;
+$color-ceuk-cyan: #0f7f8d;
 $color-ceuk-grey-100: #f3f6fb;
 $color-ceuk-grey-200: #ecf0f5;
 $color-ceuk-grey-600: #6c757d;

--- a/caps/templates/caps/council_detail.html
+++ b/caps/templates/caps/council_detail.html
@@ -24,7 +24,7 @@
 <div class="row">
     <div class="col-md-7 col-lg-8 order-md-2">
 
-        <div class="card ceuk-card ceuk-card--orange mb-gutter">
+        <div class="card ceuk-card ceuk-card--navy mb-gutter">
             <div class="card-header">
                 <h2>Declarations &amp; pledges</h2>
             </div>


### PR DESCRIPTION
Hi @zarino
The first commit improves the accessibility issues found on the council page, where teal, cyan, green, and other colours weren't passing the contrast test. I checked the other pages to see if I could find an issue with the changes, but I didn't find any.

The rest of the commits are not about accessibility but scannability on a council page.
Because there are many interactive elements(purple), we have a lot of colour on the page, which is a bit overwhelming and hard to scan. Therefore, I made the following changes to improve scannability:

- DECLARATIONS & PLEDGES card is now grey, so the titles have a neutral colour.
- The cards in the left sidebar are now grey as well. Most of them were purple, which was confusing cause we used purple mostly for interactive elements.
- The ".summary" elements are now grey. My logic is the chevron already shows they are interactive. Also, they are not the most important bit of the page. However, that whole list using purple draws your attention into that section massively, plus being on the left side part of the screen.
- Changed the hero and subheader colour from red to blue. I wanted to tune down that section a bit.

Let me know what you think

<img width="1412" alt="Screenshot 2022-05-23 at 15 47 30" src="https://user-images.githubusercontent.com/13790153/169845968-62e8592c-e37a-42b1-b1a5-a543a5d51808.png">

<img width="944" alt="Screenshot 2022-05-23 at 15 48 48" src="https://user-images.githubusercontent.com/13790153/169846224-9d94e1e2-3adf-4f15-8071-3978d32d10ed.png">

<img width="790" alt="Screenshot 2022-05-23 at 15 48 15" src="https://user-images.githubusercontent.com/13790153/169846107-bf145a3e-27e0-414c-ac1a-1064f93c5774.png">

