### PR TITLE
Fixed nowrap behaviour on mobile

### DIFF
--- a/caps/templates/caps/council_detail.html
+++ b/caps/templates/caps/council_detail.html
@@ -244,7 +244,7 @@
                 </div>
             </div>
             <div class="emissions-breakdown">
-                <div class="d-flex">
+                <div class="d-flex flex-wrap">
                     <a class="d-block emissions-breakdown__stat" href="{% url "council_projects" %}?council={{ council.id }}">
                         <div>
                             <span class="h3">{{ project_stats.total_projects|floatformat }}</span>


### PR DESCRIPTION
@zarino, I found a minor bug when testing the council page on mobile.

The data for the "EMISSIONS REDUCTION PROJECTS" overflows on mobile. I checked on the live website as well.

### Bug screenshot
<img width="207" alt="Screenshot 2022-05-23 at 15 51 56" src="https://user-images.githubusercontent.com/13790153/169849523-072b5392-7b4d-4708-9641-f6feee8e25a0.png">

### Solution
<img width="207" alt="Screenshot 2022-05-23 at 16 04 53" src="https://user-images.githubusercontent.com/13790153/169849623-b652fffd-2e33-4eed-8f31-fe35a0a43436.png">

Let me know if it fits the bill =)
