### PR TITLE
[Scorecards] Added  fix preventing overlapping of cells on main table

### DIFF
--- a/scoring/static/scoring/scss/scoring-table.scss
+++ b/scoring/static/scoring/scss/scoring-table.scss
@@ -268,14 +268,27 @@ tbody th.council-name .council-name-flex-cell{
         z-index: 2;
     }
 
-    tbody th {
-        position: relative;
-        left: 0px;
-    }
+    tbody {
 
-    tbody tr {
-        &:nth-child(odd) {
-                background-color: #F8F8F8;
+        th {
+            position: relative;
+            left: 0px;
+        }
+
+        tr {
+            &:nth-child(odd) {
+                background-color: $color-scorecard-grey-100;
+                th {
+                    background-color: $color-scorecard-grey-100;
+                }
+            }
+    
+            &:nth-child(even) {
+                background-color: $white;
+                th {
+                    background-color: $white;
+                }
+            }
         }
     }
 


### PR DESCRIPTION
I found an issue on desktop when scrolling horizontally on the main table. 

## Problem found
https://user-images.githubusercontent.com/13790153/172571073-f336bed6-413b-4bba-9096-b148f977e63f.mov


## Solution 
https://user-images.githubusercontent.com/13790153/172571520-8b61192a-9a4a-4b49-88b7-9a882a01035c.mov


