### PR TITLE
[CAPE] fix modal submit handlers

### DIFF
--- a/caps/static/caps/js/main.js
+++ b/caps/static/caps/js/main.js
@@ -180,7 +180,7 @@ $('#feedback-email').on('keyup change', function(){
     }
 })
 
-$('form[data-ajax-feedback-submit]').on('submit', function(e){
+$('form[data-ajax-submit]').on('submit', function(e){
     e.preventDefault();
     var $form = $(this);
 
@@ -204,7 +204,7 @@ $('.conditional-fields').each(function(){
     });
 });
 
-$('form[data-ajax-submit]').on('submit', function(e){
+$('form[data-ajax-feedback-submit]').on('submit', function(e){
     e.preventDefault();
     var $form = $(this);
 


### PR DESCRIPTION
The submit handler for the interstitial was no longer setting the never
show again property in local storage, but the download modal was so swap
these around.