### PR TITLE
[CAPE] don't try to drop text column when cleaning plans csv

### DIFF
--- a/caps/management/commands/postprocess.py
+++ b/caps/management/commands/postprocess.py
@@ -15,9 +15,7 @@ from caps.models import PlanDocument
 def remove_internal_data():
     out_csv = join(settings.MEDIA_ROOT, "data", settings.PROCESSED_CSV_NAME)
     df = pd.read_csv(settings.PROCESSED_CSV)
-    df = df.drop(
-        columns=["text", "unfound", "charset", "wdtk_id", "mapit_area_code", "credit"]
-    )
+    df = df.drop(columns=["unfound", "charset", "wdtk_id", "mapit_area_code", "credit"])
 
     df.to_csv(open(out_csv, "w"), index=False, header=True)
 


### PR DESCRIPTION
This is not longer present so trying to drop it causes an error.

Fixes #423