### PR TITLE
Switch to new style cookie disable settings

### DIFF
--- a/caps/templates/caps/base.html
+++ b/caps/templates/caps/base.html
@@ -35,9 +35,16 @@
             function gtag(){dataLayer.push(arguments);}
             gtag('js', new Date());
 
-            gtag('config', '{{ GOOGLE_ANALYTICS }}', {
-                'client_storage': 'none'
-            });
+            gtag('config', '{{ GOOGLE_ANALYTICS }}');
+
+            gtag("consent", "default", {
+                ad_storage: "denied",
+                analytics_storage: "denied",
+                functionality_storage: "denied",
+                personalization_storage: "denied",
+                security_storage: "denied"
+              });
+
         </script>
     {% endif %}
 </head>


### PR DESCRIPTION
Using the wrong style for cookie consent in GA-4.

See: https://stackoverflow.com/questions/67078898/how-to-disable-cookies-in-ga4

This switches to the GA4 style.