### PR TITLE
[Scorecards] Anchor elements no longer display:table

### DIFF
--- a/scoring/static/scoring/scss/about.scss
+++ b/scoring/static/scoring/scss/about.scss
@@ -13,10 +13,6 @@
         display: inline-block;
         box-shadow: inset 0 10px 0 white, inset 0 -4px 0 transparentize($color: $black, $amount: 0.9)
     }
-
-    a {
-        display: inline;
-    }
 }
 
 $colors:$color-scorecard-cyan, $color-scorecard-blue, $color-scorecard-purple, $color-scorecard-pink, $color-scorecard-orange, $color-scorecard-green-d1, $color-scorecard-navy, $color-scorecard-red;

--- a/scoring/static/scoring/scss/buttons.scss
+++ b/scoring/static/scoring/scss/buttons.scss
@@ -34,7 +34,6 @@ input::-webkit-input-placeholder {
 }
 
 a {
-    display: table;
     font-family: $font-family-sans-serif;
     font-style: normal;
     font-weight: normal;

--- a/scoring/static/scoring/scss/down-message.scss
+++ b/scoring/static/scoring/scss/down-message.scss
@@ -19,7 +19,6 @@
     }
 
     a {
-        display: inline;
         font-size: 1em !important;
         line-height: inherit;
     }

--- a/scoring/static/scoring/scss/how-to-use.scss
+++ b/scoring/static/scoring/scss/how-to-use.scss
@@ -22,8 +22,4 @@
     ul {
         padding-inline-start: 20px;
     }
-
-    a {
-        display: inline;
-    }
 }

--- a/scoring/static/scoring/scss/methodology.scss
+++ b/scoring/static/scoring/scss/methodology.scss
@@ -21,10 +21,6 @@
         }
     }
 
-    a {
-        display: inline;
-    }
-
     table {
         p {
             color: $color-scorecard-grey-900;


### PR DESCRIPTION
Fixes #457.

@lucascumsille I’m not sure whether you can remember why you set `a { display: table }` in the first place, [twelve months ago](https://github.com/mysociety/caps/commit/a0f27cbb4e65bc16b63c0739b0dd4bab0a11cc2b#diff-83f5423dfb80034b5387e0bbbd446f0df5449cc94214ddd9ffe72cb326f94e92R24) – if you can, then maybe you can comment on whether this PR will break anything non-obvious? If not, perhaps you could check over the pages of the site, and confirm you’re happy with how it all looks now. I’ve done a quick sweep, and haven’t noticed anything looking broken.