### PR TITLE
[CAPE] Refactor site URL into context mixin

### DIFF
--- a/caps/templates/caps/base.html
+++ b/caps/templates/caps/base.html
@@ -1,5 +1,6 @@
 {% load static %}
 {% load pipeline %}
+{% load hosts %}
 
 <!doctype html>
 <html lang="en">
@@ -15,8 +16,7 @@
     <meta property="og:site_name" content="CAPE">
     <meta property="og:description" content="{{ page_description|default:'The fully searchable database of climate action plans from every local authority in the UK. What is YOUR council doing to prepare for Net Zero?' }}">
     <meta property="og:type" content="website">
-    <!-- TODO: shouldn't have domain hard-coded here -->
-    <meta property="og:image" content="https://data.climateemergency.uk{{ og_image_path|default:'/static/img/og-image-cape.jpg' }}">
+    <meta property="og:image" content="{% host_url 'home' scheme 'https' %}{{ og_image_path|default:'static/img/og-image-cape.jpg' }}">
     <meta property="og:image:type" content="{{ og_image_type|default:'image/jpeg' }}">
     <meta property="og:image:width" content="{{ og_image_width|default:'2000' }}">
     <meta property="og:image:height" content="{{ og_image_height|default:'1000' }}">


### PR DESCRIPTION
Enables us to keep the site URL out of templates, making it easier to keep absolute links up to date if we ever change URL (which we’re likely to do as part of https://github.com/mysociety/caps/issues/225).

It was tempting to use the domain from `request.META.HTTP_HOST` but this is provided by the client, not the server, so ideally shouldn’t be trusted.

Eventually, I guess, we might want `SiteUrlMixin` to pull the URL out of a server environment variable, so it could be set by a provisioning script, or whatever. But hard-coding it in `mixins.py` seemed a good first step.

Fixes #146.