### PR TITLE
`variant: datauri` for Django Pipeline

### DIFF
--- a/proj/settings.py
+++ b/proj/settings.py
@@ -109,10 +109,12 @@ PIPELINE = {
         "caps": {
             "source_filenames": ("caps/scss/main.scss",),
             "output_filename": "css/caps.css",
+            "variant": "datauri",
         },
         "scoring": {
             "source_filenames": ("scoring/scss/main.scss",),
             "output_filename": "css/scoring.css",
+            "variant": "datauri",
         },
     },
     "CSS_COMPRESSOR": "django_pipeline_csscompressor.CssCompressor",


### PR DESCRIPTION
Bit hard to test this without deploying it to the live site (as Django Pipeline isn’t used in the local dev environment), but maybe this might fix the SVG/Data URI issue in #462.