### PR TITLE
Reframe “Features” page as “Plans” page, with download and search

### DIFF
--- a/caps/static/caps/scss/site-header.scss
+++ b/caps/static/caps/scss/site-header.scss
@@ -10,8 +10,7 @@
         background-color: $color-ceuk-navy;
     }
 
-    .page-purple &,
-    .page-tags & {
+    .page-purple & {
         background-color: $color-ceuk-purple;
     }
 

--- a/caps/static/caps/scss/site-hero.scss
+++ b/caps/static/caps/scss/site-hero.scss
@@ -24,8 +24,7 @@
         background-image: linear-gradient(0deg, darken($color-ceuk-navy, 2%), darken($color-ceuk-navy, 4%));
     }
 
-    .page-purple &,
-    .page-tags & {
+    .page-purple & {
         background-color: darken($color-ceuk-purple, 2%);
         background-image: linear-gradient(0deg, darken($color-ceuk-purple, 2%), darken($color-ceuk-purple, 4%));
     }

--- a/caps/templates/caps/base.html
+++ b/caps/templates/caps/base.html
@@ -81,7 +81,7 @@
 
     {% block before_content %}{% endblock %}
 
-    <div class="site-content">
+    <div class="site-content {% block extra_content_classes %}{% endblock %}">
         <div class="container-fluid">
             {% block content %}{% endblock %}
             {% include 'caps/includes/alpha-banner.html' %}

--- a/caps/templates/caps/home.html
+++ b/caps/templates/caps/home.html
@@ -8,49 +8,7 @@
     {% include 'caps/includes/location-search-form.html' %}
 </div>
 
-<div class="row">
-    <div class="col-md-5 d-sm-flex">
-
-        <div class="card ceuk-card ceuk-card--red mb-gutter homepage-stat">
-            <div class="card-body p-md-4 p-lg-5 d-flex flex-column">
-                <h2 class="mb-0">{{ percent_councils_with_plan }}% of councils have a plan</h2>
-                <div class="progress mt-4 mb-3">
-                    <div class="progress-bar bg-red" role="progressbar" style="width: {{ percent_councils_with_plan }}%" aria-valuenow="{{ percent_councils_with_plan }}" aria-valuemin="0" aria-valuemax="100"></div>
-                </div>
-                <a href="{% url 'council_list' %}" class="d-flex align-items-center mt-auto" data-show-interstitial>
-                    Browse and compare all {{ total_councils }} councils
-                    {% include 'caps/icons/chevron-right.html' with classes='ml-1' role='presentation' %}
-                </a>
-                <a data-show-feedback-modal href="{{ MEDIA_URL }}data/plans/plans.zip" class="d-flex align-items-center mt-3">
-                    Download ZIP archive of {{ total_plans }} documents ({{ plan_zip_size }})
-                    {% include 'caps/icons/download.html' with classes='ml-1' role='presentation' %}
-                </a>
-                <div class="mt-3">
-                    <small>Last updated: {{ last_update }}.</small>
-                </div>
-            </div>
-        </div>
-
-    </div>
-    <div class="col-md-7 d-sm-flex">
-
-        <div class="card ceuk-card ceuk-card--purple mb-gutter homepage-search-plans">
-            <div class="card-body p-md-4 p-lg-5">
-                <h2>The UK’s open database of council climate action plans</h2>
-                {% include 'caps/includes/text-search-form.html' %}
-              {% if popular_searches %}
-                <h3 class="mt-4 mb-2">Popular searches:</h3>
-                <ul class="list-inline mb-0">
-                  {% for suggestion in popular_searches %}
-                    <li class="list-inline-item mr-3"><a href="{% url 'search_results' %}?q={{ suggestion.user_query }}&inorganic=1" data-show-interstitial>{{ suggestion.user_query }}</a></li>
-                  {% endfor %}
-                </ul>
-              {% endif %}
-            </div>
-        </div>
-
-    </div>
-</div>
+{% include 'caps/includes/plans-download-and-search.html' %}
 
 {% include 'caps/includes/data-feedback-modal.html' %}
 

--- a/caps/templates/caps/includes/plans-download-and-search.html
+++ b/caps/templates/caps/includes/plans-download-and-search.html
@@ -1,0 +1,43 @@
+<div class="row">
+    <div class="col-md-5 d-sm-flex">
+
+        <div class="card ceuk-card ceuk-card--red mb-gutter homepage-stat">
+            <div class="card-body p-md-4 p-lg-5 d-flex flex-column">
+                <h2 class="mb-0">{{ percent_councils_with_plan }}% of councils have a plan</h2>
+                <div class="progress mt-4 mb-3">
+                    <div class="progress-bar bg-red" role="progressbar" style="width: {{ percent_councils_with_plan }}%" aria-valuenow="{{ percent_councils_with_plan }}" aria-valuemin="0" aria-valuemax="100"></div>
+                </div>
+                <a href="{% url 'council_list' %}" class="d-flex align-items-center mt-auto" data-show-interstitial>
+                    Browse and compare all {{ total_councils }} councils
+                    {% include 'caps/icons/chevron-right.html' with classes='ml-1' role='presentation' %}
+                </a>
+                <a data-show-feedback-modal href="{{ MEDIA_URL }}data/plans/plans.zip" class="d-flex align-items-center mt-3">
+                    Download ZIP archive of {{ total_plans }} documents ({{ plan_zip_size }})
+                    {% include 'caps/icons/download.html' with classes='ml-1' role='presentation' %}
+                </a>
+                <div class="mt-3">
+                    <small>Last updated: {{ last_update }}.</small>
+                </div>
+            </div>
+        </div>
+
+    </div>
+    <div class="col-md-7 d-sm-flex">
+
+        <div class="card ceuk-card ceuk-card--purple mb-gutter homepage-search-plans">
+            <div class="card-body p-md-4 p-lg-5">
+                <h2>{{ search_title|default:"The UK’s open database of council climate action plans" }}</h2>
+                {% include 'caps/includes/text-search-form.html' with label_text=search_label %}
+              {% if popular_searches %}
+                <h3 class="mt-4 mb-2">Popular searches:</h3>
+                <ul class="list-inline mb-0">
+                  {% for suggestion in popular_searches %}
+                    <li class="list-inline-item mr-3"><a href="{% url 'search_results' %}?q={{ suggestion.user_query }}&inorganic=1" data-show-interstitial>{{ suggestion.user_query }}</a></li>
+                  {% endfor %}
+                </ul>
+              {% endif %}
+            </div>
+        </div>
+
+    </div>
+</div>

--- a/caps/templates/caps/includes/site-header.html
+++ b/caps/templates/caps/includes/site-header.html
@@ -17,7 +17,7 @@
             <div class="collapse navbar-collapse" id="primaryNav">
                 <div class="navbar-nav">
                     <a class="nav-link" href="{% url 'council_list' %}">Councils</a>
-                    <a class="nav-link" href="{% url 'tag_list' %}">Browse by feature</a>
+                    <a class="nav-link" href="{% url 'tag_list' %}">Plans</a>
                     <a class="nav-link" href="{% url 'council_projects' %}">Emissions reduction</a>
                     <a class="nav-link" href="{% url 'about_data' %}">Data</a>
                     <a class="nav-link" href="{% url 'about' %}">About</a>

--- a/caps/templates/caps/tag_list.html
+++ b/caps/templates/caps/tag_list.html
@@ -1,19 +1,27 @@
 {% extends "caps/base.html" %}
 
-{% block bodyclass %}page-tags{% endblock %}
-
 {% block before_content %}
 
 <div class="site-hero">
-    <div class="container-fluid">
-        <h1 class="my-0">Browse by feature</h1>
-        <p class="mt-2 mb-0 lead">We’ve selected the councils with the most exemplary plans in a number of topic areas</p>
+    <div class="container-fluid pb-5">
+        <h1 class="my-0" style="max-width: 16em;">The UK’s open database of council climate action plans</h1>
     </div>
 </div>
 
 {% endblock %}
 
+{% block extra_content_classes %}pt-0{% endblock %}
+
 {% block content %}
+
+<div class="mt-n5">
+    {% include 'caps/includes/plans-download-and-search.html' with search_title="Search across every climate action plan in the UK" search_label="Enter a search term" %}
+</div>
+
+<div class="my-5 text-center">
+    <h2>What makes a good plan?</h2>
+    <p class="lead mb-0">We’ve selected the councils with the most exemplary plans in a number of topic areas</p>
+</div>
 
 <div class="row">
   {% for tag in tags %}

--- a/caps/urls.py
+++ b/caps/urls.py
@@ -1,6 +1,7 @@
 from django.urls import include, path
 from django.contrib import admin
 from django.conf import settings
+from django.views.generic.base import RedirectView
 
 import haystack.generic_views
 from caps.forms import HighlightedSearchForm
@@ -16,14 +17,16 @@ router.register(r"commitments", api_views.CommitmentsViewSet)
 urlpatterns = [
     path("", views.HomePageView.as_view(), name="home"),
     path("councils/<slug:slug>/", views.CouncilDetailView.as_view(), name="council"),
-    path("features/<slug:slug>/", views.TagDetailView.as_view(), name="tag"),
+    path("features/<slug:slug>/", RedirectView.as_view(pattern_name="tag")),
+    path("plans/<slug:slug>/", views.TagDetailView.as_view(), name="tag"),
     path(
         "search/",
         views.SearchResultsView.as_view(form_class=HighlightedSearchForm),
         name="search_results",
     ),
     path("councils/", views.CouncilListView.as_view(), name="council_list"),
-    path("features/", views.TagListView.as_view(), name="tag_list"),
+    path("features/", RedirectView.as_view(pattern_name="tag_list")),
+    path("plans/", views.TagListView.as_view(), name="tag_list"),
     path(
         "projects/",
         views.CouncilProjectsListView.as_view(),


### PR DESCRIPTION
- Replace `/features*` URLs with `/plans*`
- Rename “Features” to “Plans” in main nav
- Break homepage plan download and search section into its own partial (plans-download-and-search.html) and include that in both the homepage and the top of the new “Plans” page.
- New `add_context_for_plans_download_and_search` function in views.py, to provide context for the plans-download-and-search.html partial.
- Remove purple hero background for new “Plans” page.
- Add `extra_content_classes` block for adding additional classes to the `site-content` element.

TODO: Handle redirects from /features* => /plans*?

TODO: Pre-warn Vixen about the change, before this goes live? /cc @MyfanwyNixon 

Fixes #416.

![Screenshot 2023-03-17 at 10-54-44 Council climate action plans](https://user-images.githubusercontent.com/739624/225886946-2ab1757a-438f-4406-a27e-c8fac863e55f.png)
