### PR TITLE
Add 'Your Representatives' box to council page

### DIFF
--- a/caps/helpers/council_navigation.py
+++ b/caps/helpers/council_navigation.py
@@ -44,6 +44,12 @@ council_menu = [
         desc="What the council is responsible for and how it relates to climate change.",
     ),
     MenuItem(
+        slug="representatives",
+        title="Your representatives",
+        color="blue",
+        desc="Find your representatives.",
+    ),
+    MenuItem(
         slug="declarations",
         title="Declarations & pledges",
         color="cyan",

--- a/caps/static/caps/js/main.js
+++ b/caps/static/caps/js/main.js
@@ -96,6 +96,10 @@ var shouldShowInterstitial = function() {
             return false;
         }
     }
+    if ( Math.random() < (1 - 0.25) ) {
+        // Only show survey to 25% of users.
+        return false;
+    }
     return true;
 }
 

--- a/caps/static/caps/scss/content-navbar.scss
+++ b/caps/static/caps/scss/content-navbar.scss
@@ -8,6 +8,7 @@ $content-index-array: (
     'powers',
     'declarations',
     'emissions',
+    'representatives',
     'climate-documents',
     'emissions-reduction-projects',
     'scorecard',

--- a/caps/templates/caps/council_cards/local-polling.html
+++ b/caps/templates/caps/council_cards/local-polling.html
@@ -12,8 +12,9 @@
 This data is based on a national poll that has been adjusted for the demographics of the local area.
 [Learn more about MRP polling]({% url 'content' 'mrp' %}).
 
-Polling conducted by [PublicFirst for Onward](https://www.publicfirst.co.uk/new-public-first-polling-for-onward.html),
+Based on polling conducted by [PublicFirst for Onward](https://www.publicfirst.co.uk/new-public-first-polling-for-onward.html),
 and [Survation for RenewableUK](https://www.survation.com/polling-in-every-constituency-in-britain-shows-strong-support-for-building-wind-farms-to-drive-down-consumer-bills/) in 2022.
+Constituency level data has been adapted to local authority areas.
 
 {% endmarkdown %}
 {% endinfobox %}

--- a/caps/templates/caps/council_cards/representatives.html
+++ b/caps/templates/caps/council_cards/representatives.html
@@ -1,0 +1,45 @@
+{% extends "caps/council_cards/base.html" %}
+
+{% load caps_templatetags %}
+
+{% block title %}
+    Your representatives
+{% endblock title %}
+
+{% block cardbody %}
+    {% infobox %}
+        {% markdown %}
+            We also run [WriteToThem.com](https://www.writetothem.com{% if postcode %}?pc={{postcode}}{% endif %}), which you can use to find out all your representatives
+            from different layers of local, devolved, and national democracy.
+            
+            You can also use it to send a message to your councillors, MP, or other representatives.
+        {% endmarkdown %}
+    {% endinfobox %}
+
+    <div class="card-body bg-green-light">
+    <form action="https://www.writetothem.com/who"
+            class="form-row flex-wrap align-items-center">
+        <div class="col-auto flex-shrink-0 d-flex">
+                    <label for="search-write-to-them" class="align-middle" style="margin-bottom:0px">Your postcode:</label>
+
+        </div>
+        <div class="col-auto flex-shrink-1 flex-grow-1" style="max-width: 450px">
+            <input type="search"
+                    class="form-control form-control-sm"
+                    name="pc"
+                    id="search-write-to-them"
+                    value="{% if postcode %}{{ postcode.upper }}{% endif %}"
+                    placeholder="e.g. M1 1AG">
+        </div>
+        <div class="col-auto flex-shrink-0 d-flex">
+            <button type="submit" class="btn btn-purple btn-sm d-flex align-items-center">
+                <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi " role="presentation" fill="currentColor" xmlns="http://www.w3.org/2000/svg"><path d="M6.6 0C3 0 0 3 0 6.6a6.7 6.7 0 0 0 10.4 5.5l3.6 3.6c.5.4 1.2.4 1.7 0 .4-.5.4-1.2 0-1.7L12 10.4A6.6 6.6 0 0 0 6.7 0zm0 2.3c2.4 0 4.3 2 4.3 4.3C11 9 9 11 6.6 11S2.3 9 2.3 6.6s2-4.3 4.3-4.3z"/></svg>
+
+                <span class="ml-2">Find on WriteToThem.com</span>
+            </button>
+        </div>
+    </form>
+</div>
+
+
+{% endblock cardbody %}


### PR DESCRIPTION
This PR adds 'Your Representatives' box to council page, which links to WriteToThem.

When doing a postcode search, a session cookie will be generated with the postcode, which is then used to pre-populate the form. Form also works fine without this.

With cookie:

![image](https://github.com/mysociety/caps/assets/8157058/75f511a9-3a83-4d0e-b131-0bead6471a97)

Without cookie:

![image](https://github.com/mysociety/caps/assets/8157058/61eb6914-340d-4409-9f14-279df780d703)

Also some small tweaks elsewhere:

- Reduced frequency of initial survey (25% chance rather than 100% on second page view).
- Light change to description of local polling. 