### PR TITLE
Update plans import approach

### DIFF
--- a/caps/management/commands/add_council_websites.py
+++ b/caps/management/commands/add_council_websites.py
@@ -17,7 +17,12 @@ SCOTTISH_TWITTER_CSV = join(settings.DATA_DIR, "scottish_twitter.csv")
 
 
 def get_dom(url):
-    local_filename, headers = urllib.request.urlretrieve(url)
+
+    headers = {
+        "User-Agent": "CAPE Provisioning/0.0 (cape.mysociety.org)",
+    }
+
+    local_filename, headers = urllib.request.urlretrieve(url, headers=headers)
 
     with open(local_filename, "r") as reader:
         page = reader.read()

--- a/caps/management/commands/add_text.py
+++ b/caps/management/commands/add_text.py
@@ -1,4 +1,12 @@
-from os.path import join, basename, splitext, isfile
+"""
+This management command is no longer used!
+
+There's a prepare_text method in search_indexes.py
+that uses the build in haystack text extraction stuff
+for different file formats. 
+
+"""
+
 import glob
 
 import pandas as pd

--- a/caps/management/commands/fetch_and_process_promises.py
+++ b/caps/management/commands/fetch_and_process_promises.py
@@ -1,5 +1,6 @@
-from django.core.management.base import BaseCommand
+import pandas as pd
 from django.conf import settings
+from django.core.management.base import BaseCommand
 
 from caps.import_utils import (
     add_authority_codes,
@@ -41,6 +42,11 @@ class Command(BaseCommand):
         get_promises()
         print("replacing promises headers")
         replace_headers()
+        df = pd.read_csv(settings.PROMISES_CSV)
+        # remove any rows with a blank council cell
+        # seems to be loose ones at the end of the file
+        df = df.dropna(subset=["council"])
+        df.to_csv(settings.PROMISES_CSV, index=False, header=True)
         print("adding council codes to promises")
         add_authority_codes(settings.PROMISES_CSV)
         add_gss_codes(settings.PROMISES_CSV)

--- a/caps/management/commands/import_plans.py
+++ b/caps/management/commands/import_plans.py
@@ -367,10 +367,8 @@ class Command(BaseCommand):
             "start_year": start_year,
             "end_year": end_year,
             "date_last_found": date_from_text(row["date_retrieved"]),
-            "title": "",
+            "title": char_from_text(row["title"]),
         }
-        if char_from_text(row["title_checked"]).lower() == "y":
-            defaults["title"] = char_from_text(row["title"])
 
         return defaults
 

--- a/caps/management/commands/preprocess.py
+++ b/caps/management/commands/preprocess.py
@@ -43,6 +43,8 @@ def set_file_attributes(df, index, content_type, extension):
         df.at[index, "file_type"] = "xlsx"
     elif content_type == "application/vnd.ms-excel.sheet.macroenabled.12":
         df.at[index, "file_type"] = "xlsm"
+    elif content_type == "application/msword":
+        df.at[index, "file_type"] = "doc"
     else:
         print("Unknown content type: " + content_type)
 

--- a/caps/management/commands/preprocess.py
+++ b/caps/management/commands/preprocess.py
@@ -1,23 +1,17 @@
-from os.path import join, basename, splitext, isfile
 import os
-import sys
-
-
-import requests
-from urllib.parse import urlparse
-import urllib3
-
-import pandas as pd
-import numpy
-
-from django.core.management.base import BaseCommand, CommandError
-from django.conf import settings
-
-from caps.models import PlanDocument
-from caps.import_utils import get_google_sheet_as_csv, replace_csv_headers
-
 import ssl
+import sys
+from os.path import basename, isfile, join, splitext
+from urllib.parse import urlparse
 
+import numpy
+import pandas as pd
+import requests
+import urllib3
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+from caps.import_utils import get_google_sheet_as_csv, replace_csv_headers
+from caps.models import PlanDocument
 
 ssl._create_default_https_context = ssl._create_unverified_context
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)

--- a/caps/templates/caps/includes/text-search-result.html
+++ b/caps/templates/caps/includes/text-search-result.html
@@ -1,7 +1,7 @@
 <div class="ceuk-card card mb-3 mb-lg-4">
     <div class="card-body mb-n3">
         <h2 class="h4"><a href="{% url 'council' result.object.council.slug %}">{{ result.object.council.name }}</a></h2>
-        <a class="d-flex align-items-center mb-3" data-plan-id="{{ result.object.id }}" data-council-slug="{{ result.object.council.slug }}" href="{{ result.object.file.url }}">
+        <a class="d-flex align-items-center mb-3" data-plan-id="{{ result.object.id }}" data-council-slug="{{ result.object.council.slug }}" href="{{ result.object.url }}">
             {% include 'caps/icons/file.html' with classes='mr-2' role='presentation' %}
             Direct link to {{ result.object.get_document_type }} ({{ result.object.file_type|upper }})
         </a>

--- a/caps/tests/test_import.py
+++ b/caps/tests/test_import.py
@@ -266,18 +266,6 @@ class ImportPlansTestCase(ImportTestCase):
             plans = PlanDocument.objects.filter(council=west_bors)
             self.assertEqual(len(plans), 0)
 
-    def test_add_name(self):
-        bors = Council.objects.get(authority_code="BORS")
-        with self.settings(PROCESSED_CSV="caps/tests/test_processed_plan_names.csv"):
-            out = self.call_command(confirm_changes=1)
-            west_bors = Council.objects.get(authority_code="WBRS")
-
-            plan = PlanDocument.objects.filter(council=bors).all()[0]
-            self.assertEqual(plan.title, "Bors Climate Plan")
-
-            plan = PlanDocument.objects.filter(council=west_bors).all()[0]
-            self.assertEqual(plan.title, "")
-
 
 class ImportPromisesTestCase(ImportTestCase):
 


### PR DESCRIPTION
I've changed the google sheet to a new simpler format, given it now just powers CAPE. 

IMPORTANT: the import will not work until this has merged because I've done this. 

This also will interpret a 'True' in the `out_of_date` column to remove from the import, letting us keep track of changes in the sheet. 

Few other loose changes:

- Added retry approach to scraper, seems to get a few of the docs it was struggling with before.
- Fixed link to document from search page - which didn't work for non-pdfs.




