### PR TITLE
[scorecards] check for disolved councils on councils page

### DIFF
--- a/scoring/templates/scoring/council.html
+++ b/scoring/templates/scoring/council.html
@@ -28,6 +28,8 @@
                 <h3 class="mb-3">About this council</h3>
                 {% if new_council %}
                 <p>This council was created on April 1, 2023 so was not included in the 2021 Scorecards.</p>
+                {% elif old_council %}
+                <p>This council was dissolved on {{ council.end_date }} so was not included in the 2021 Scorecards.</p>
                 {% else %}
                 {% if plan_score.top_performer %}
                 <p class="top-performer.active mb-0">This council is a top performer within {% include 'caps/includes/authority_type.html' with group=authority_type %} councils.</p>
@@ -104,7 +106,7 @@
     </div>
 </div>
 
-{% if not new_council %}
+{% if not new_council and not old_council %}
 <div class="container council-page mt-4">
     <div class="row">
         <div class="col-md-12">

--- a/scoring/views.py
+++ b/scoring/views.py
@@ -1,32 +1,29 @@
 from collections import defaultdict
 from datetime import date
 
-from django.views.generic import DetailView, TemplateView
-from django.contrib.auth.views import LoginView, LogoutView
-from django.db.models import Subquery, OuterRef, Count, Sum, F
-from django.shortcuts import resolve_url
-from django.utils.text import Truncator
-from django.utils.decorators import method_decorator
-from django.views.decorators.cache import cache_control
+from caps.models import Council, Promise
+from caps.views import BaseLocationResultsView
 from django.conf import settings
-
+from django.contrib.auth.views import LoginView, LogoutView
+from django.db.models import Count, F, OuterRef, Subquery, Sum
+from django.shortcuts import resolve_url
+from django.utils.decorators import method_decorator
+from django.utils.text import Truncator
+from django.views.decorators.cache import cache_control
+from django.views.generic import DetailView, TemplateView
 from django_filters.views import FilterView
 
-from caps.models import Council, Promise
+from scoring.filters import PlanScoreFilter, QuestionScoreFilter
+from scoring.forms import ScoringSort
+from scoring.mixins import AdvancedFilterMixin, CheckForDownPageMixin
 from scoring.models import (
+    PlanQuestion,
+    PlanQuestionScore,
     PlanScore,
     PlanScoreDocument,
     PlanSection,
     PlanSectionScore,
-    PlanQuestion,
-    PlanQuestionScore,
 )
-from scoring.filters import PlanScoreFilter, QuestionScoreFilter
-
-from scoring.forms import ScoringSort
-
-from caps.views import BaseLocationResultsView
-from scoring.mixins import CheckForDownPageMixin, AdvancedFilterMixin
 
 cache_settings = {
     "max-age": 60,
@@ -200,6 +197,12 @@ class CouncilView(CheckForDownPageMixin, DetailView):
         if council.start_date is not None and council.start_date >= new_council_date:
             context["authority_type"] = group
             context["new_council"] = True
+            return context
+
+        old_council_date = date(year=2021, month=4, day=1)
+        if council.end_date is not None and council.end_date <= old_council_date:
+            context["authority_type"] = group
+            context["old_council"] = True
             return context
 
         context["all_councils"] = Council.objects.filter(


### PR DESCRIPTION
While we were checking for councils that had not been created at the time plans were scored we weren't checking for councils that had been dissolved. This fixes that.

Fixes #564