### PR TITLE
[Scorecards] Load council type tables over Ajax

### DIFF
--- a/scoring/static/scoring/js/main.js
+++ b/scoring/static/scoring/js/main.js
@@ -364,3 +364,57 @@ forEachElement('.js-methodology-council-autocomplete', function(input){
         container.setAttribute('data-methodology-active-council-type', council.council_type);
     });
 });
+
+function ajaxLoadCouncilTypeScorecard(url) {
+    var selectors = [
+        '#council-type-filter',
+        '#advancedFilter .modal-body',
+        '.table-header h3',
+        '.scorecard-table'
+    ];
+
+    selectors.forEach(function(selector){
+        document.querySelector(selector).classList.add('loading-shimmer');
+    });
+
+    fetch(url)
+    .then(function(response) {
+        return response.text()
+    })
+    .then(function(html) {
+        var parser = new DOMParser();
+        var doc = parser.parseFromString(html, "text/html");
+        selectors.forEach(function(selector){
+            document.querySelector(selector).replaceWith(doc.querySelector(selector));
+        });
+    })
+    .catch(function(err) {
+        window.location.href = url;
+    });
+}
+
+if ( typeof window.fetch !== 'undefined' ) {
+    document.addEventListener('click', function(e){
+        if ( e.target.matches('#council-type-filter a') ) {
+            e.preventDefault();
+            var href = e.target.href;
+            history.pushState({}, '', href);
+            ajaxLoadCouncilTypeScorecard(href);
+        }
+    });
+
+    var councilTypePaths = [
+        '/',
+        '/scoring/district/',
+        '/scoring/county/',
+        '/scoring/combined/',
+        '/scoring/northern-ireland/'
+    ];
+
+    window.addEventListener('popstate', function(e){
+        var url = new URL(window.location.href);
+        if ( councilTypePaths.indexOf(url.pathname) != -1 ) {
+            ajaxLoadCouncilTypeScorecard(window.location.href);
+        }
+    });
+}

--- a/scoring/static/scoring/scss/loading-shimmer.scss
+++ b/scoring/static/scoring/scss/loading-shimmer.scss
@@ -1,0 +1,27 @@
+.loading-shimmer {
+    position: relative;
+    filter: grayscale(50%);
+    opacity: 0.5;
+
+    &:after {
+        content: "";
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        z-index: 100;
+        background-image: linear-gradient(90deg, rgba(#fff, 0) 33%, rgba(#fff, 0.6) 50%, rgba(#fff, 0) 66%);
+        background-size: 300% 100%;
+        animation: shimmer 2s infinite;
+    }
+
+    @keyframes shimmer {
+        0% {
+            background-position: right;
+        }
+        100% {
+            background-position: left;
+        }
+    }
+}

--- a/scoring/static/scoring/scss/main.scss
+++ b/scoring/static/scoring/scss/main.scss
@@ -95,3 +95,4 @@
 // @import "about";
 // @import "toggle-section";
 @import "toggle-buttons";
+@import "loading-shimmer";

--- a/scoring/templates/scoring/home.html
+++ b/scoring/templates/scoring/home.html
@@ -38,28 +38,6 @@
     </div>
 
     <div class="container home pt-5">
-        <h2 class="mb-4 mb-lg-5">Scorecards results</h2>
-
-        {% comment %} <div class="row">
-            <div class="col-12 col-lg-5">
-                <div class="card h-100">
-                    <div class="card-header text-bg-secondary ">Filter the table by type of council</div>
-                    <div class="card-body">
-                        {% include 'scoring/includes/main-filter.html' %}
-                    </div>
-                </div>
-            </div>
-
-            <div class="col-12 col-lg-7 mt-3 mt-lg-0">
-                <div class="card h-100">
-                    <div class="card-header text-bg-secondary ">Check the rank by sections</div>
-                    <div class="card-body d-flex flex-row flex-wrap" style="gap:0.5rem">
-                        {% include 'scoring/includes/section-list.html' %}
-                    </div>
-                </div>
-            </div>
-        </div> {% endcomment %}
-
         <div class="row">
             <div class="col-12 col-lg-4">
                 <div class="card h-100">
@@ -98,23 +76,9 @@
             </div>
         </div>
 
-        {% comment %} <div class="container">
-            <div class="row">
-                <div class="col-1 text-bg-category-1">Category 1</div>
-                <div class="col-1 text-bg-category-2">Category 2</div>
-                <div class="col-1 text-bg-category-3">Category 3</div>
-                <div class="col-1 text-bg-category-4">Category 4</div>
-                <div class="col-1 text-bg-category-5">Category 5</div>
-                <div class="col-1 text-bg-category-6">Category 6</div>
-                <div class="col-1 text-bg-category-7">Category 7</div>
-                <div class="col-1 text-bg-category-8">Category 8</div>
-                <div class="col-1 text-bg-category-9">Category 9</div>
-            </div>
-        </div> {% endcomment %}
-
         <div class="my-5 mx-auto position-relative" style="max-width: 1440px;">
-            <div class="table-header mb-4">
-                <div>
+            <div class="table-header mb-4 d-md-flex align-items-end">
+                <div class="me-md-auto">
                     <h3 class="d-inline-block">
                         <span>{{ authority_type_label }}</span>
                         {% if filter_descs %}
@@ -128,9 +92,7 @@
                     </h3>
                     <p class="mb-0 fs-5">Councils Action Scorecards</p>
                 </div>
-                {% if authority_type == 'single' or authority_type == 'country' or authority_type == 'district' %}
                 {% include 'scoring/includes/advanced-filter.html' %}
-                {% endif %}
             </div>
 
 

--- a/scoring/templates/scoring/includes/advanced-filter.html
+++ b/scoring/templates/scoring/includes/advanced-filter.html
@@ -1,5 +1,4 @@
-
-<button type="button" class="btn btn-primary mt-3" data-bs-toggle="modal" data-bs-target="#advancedFilter">
+<button type="button" class="btn btn-primary mt-3 mt-md-0 mb-md-1" data-bs-toggle="modal" data-bs-target="#advancedFilter">
     Advanced filters
 </button>
 

--- a/scoring/templates/scoring/includes/main-filter.html
+++ b/scoring/templates/scoring/includes/main-filter.html
@@ -1,7 +1,7 @@
 <form class="form">
     <input class="form-control searchbar js-location-jump-autocomplete" type="search" placeholder="Council name" aria-label="Council name">
     <!-- <button class="btn btn-outline-success my-2 my-sm-0" type="submit">Search</button> -->
-    <div class="type-council-option-wrapper mt-4">
+    <div class="type-council-option-wrapper mt-4" id="council-type-filter">
         <a class="mb-1 btn btn-sm btn-outline-primary {% if authority_type == 'single' %} active{% endif %}" href="{% include 'scoring/includes/scoring_url.html' with slug='single' %}">Single Tier</a>
         <a class="mb-1 btn btn-sm btn-outline-primary {% if authority_type == 'district' %} active{% endif %}" href="{% include 'scoring/includes/scoring_url.html' with slug='district' %}">District</a>
         <a class="mb-1 btn btn-sm btn-outline-primary {% if authority_type == 'county' %} active{% endif %}" href="{% include 'scoring/includes/scoring_url.html' with slug='county' %}">County</a>


### PR DESCRIPTION
- JavaScript for intercepting council type button presses, and loading the pages over Ajax instead, pulling out specific elements from the new page, and injecting them into the current page, so that we don’t have to mess with resetting event listeners on any parent elements.
- Update browser URL with History.pushState, and (re-)load pages over Ajax on popState event, so that browser back/forward buttons work as you’d expect.
- “loading shimmer” animation for elements being replaced by Ajax.
- Remove conditional around “Advanced filters” button – no need to hide the Advanced Filters for Combined Authorities or NI Councils.
- Save some vertical space in the viewport by removing the useless “Scorecards results” heading and moving the “Advanced filters” button into a space above the table on the right.

Fixes #512.

https://github.com/mysociety/caps/assets/739624/9b905769-0ef6-4015-9ca4-f9ecde0568ba
