### PR TITLE
generate 404 page instead of 500 when section or score not found

### DIFF
--- a/scoring/templates/scoring/council.html
+++ b/scoring/templates/scoring/council.html
@@ -79,7 +79,7 @@
     </div>
 </div>
 
-{% if not new_council and not old_council %}
+{% if not new_council and not old_council and not no_plan %}
 <div class="container council-page py-5 js-dynamic-content" data-active-source-type="default">
 
     <h3>{{ council.short_name }}’s 2023 Action Scorecard</h3>
@@ -327,6 +327,25 @@
 
     </table>
 
+</div>
+{% else %}
+<div class="py-5 border-bottom">
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-5 mb-5 mb-lg-0">
+                <h2 class="h3 mb-3">No scorecard available</h2>
+                <p>
+                {% if new_council %}
+                  This council was recently created when the scorecards were marked so was not included.
+                {% elif old_council %}
+                  This council had been disbanded when the scorecards were marked so was not included.
+                {% else
+                  We do not currently have a scorecard for this council.
+                {% endif %}
+                </p>
+            </div>
+        </div>
+    </div>
 </div>
 {% endif %}
 

--- a/scoring/views.py
+++ b/scoring/views.py
@@ -6,7 +6,7 @@ from datetime import date
 from django.conf import settings
 from django.contrib.auth.views import LoginView, LogoutView
 from django.db.models import Count, F, OuterRef, Subquery, Sum
-from django.shortcuts import resolve_url, reverse
+from django.shortcuts import get_object_or_404, resolve_url, reverse
 from django.utils.decorators import method_decorator
 from django.utils.text import Truncator
 from django.views.decorators.cache import cache_control
@@ -398,7 +398,7 @@ class SectionView(CheckForDownPageMixin, DetailView):
     alt_map = dict((ca, non_ca) for non_ca, ca in combined_alt_map.items())
 
     def get_object(self):
-        return PlanSection.objects.get(code=self.kwargs["code"])
+        return get_object_or_404(PlanSection, code=self.kwargs["code"])
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/scoring/views.py
+++ b/scoring/views.py
@@ -265,8 +265,12 @@ class CouncilView(CheckForDownPageMixin, DetailView):
             "all_councils"
         ] = Council.objects.all()  # for location search autocomplete
 
+        try:
+            plan_score = PlanScore.objects.get(council=council, year=settings.PLAN_YEAR)
+        except PlanScore.DoesNotExist:
+            context["no_plan"] = True
+
         promises = Promise.objects.filter(council=council).all()
-        plan_score = PlanScore.objects.get(council=council, year=settings.PLAN_YEAR)
         plan_urls = PlanScoreDocument.objects.filter(plan_score=plan_score)
         sections = PlanSectionScore.sections_for_council(
             council=council, plan_year=settings.PLAN_YEAR


### PR DESCRIPTION
tidies up a few loose ends of places where we're not handling missing objects correctly.