### PR TITLE
Switch to cookieless approach to scorecards

### DIFF
--- a/scoring/templates/scoring/base.html
+++ b/scoring/templates/scoring/base.html
@@ -23,16 +23,14 @@
     <meta property="og:image:height" content="{{ og_image_height|default:'675' }}">
     {% stylesheet 'scoring' %}
     {% if GOOGLE_ANALYTICS_SCORECARDS %}
-        <!-- Global site tag (gtag.js) - Google Analytics -->
-        <script async src="https://www.googletagmanager.com/gtag/js?id={{ GOOGLE_ANALYTICS_SCORECARDS }}"></script>
+        <script defer>Object.defineProperty(document,"cookie",{get:function(){var t=Object.getOwnPropertyDescriptor(Document.prototype,"cookie").get.call(document);return t.trim().length>0&&(t+="; "),t+="_ga=GA1.1."+Math.floor(1e9*Math.random())+"."+Math.floor(1e9*Math.random())},set:function(t){t.trim().startsWith("_ga")||Object.getOwnPropertyDescriptor(Document.prototype,"cookie").set.call(document,t)}});</script>
+        <script defer src="https://www.googletagmanager.com/gtag/js?id={{ GOOGLE_ANALYTICS_SCORECARDS }}"></script>
         <script>
+            var client_id = Math.floor(Math.random() * 1000000000) + '.' + Math.floor(Math.random() * 1000000000);
             window.dataLayer = window.dataLayer || [];
             function gtag(){dataLayer.push(arguments);}
             gtag('js', new Date());
-
-            gtag('config', '{{ GOOGLE_ANALYTICS_SCORECARDS }}', {
-                'client_storage': 'none'
-            });
+            gtag('config','{{ GOOGLE_ANALYTICS_SCORECARDS }}', {'client_id': client_id, 'cookie_expires': 1});
         </script>
     {% endif %}
 </head>


### PR DESCRIPTION
Switch from old style (doesn't work) to new style (does work) approach to running google analytics without cookies. 