### PR TITLE
Update 2023 Methodology on 2022 site

### DIFF
--- a/scoring/templates/scoring/home.html
+++ b/scoring/templates/scoring/home.html
@@ -11,8 +11,8 @@
                 <b class="d-block" style="font-size: 0.75em; line-height: 1.3;">Coming soon:</b>
                 Council Climate Action Scorecards 2023
             </h2>
-            <p class="mx-auto mb-3 mb-lg-4" style="max-width: 38em;">In mid-October 2023 we’ll be releasing the results of the Council Climate Action Scorecards, scoring the actual climate action they have taken. We published our draft methodology for the the Council Climate Action Scorecards 2023 in November 2022.</p>
-            <p><a href="{% url 'methodology' %}" class="btn btn-blue is--light">Read the draft methodology</a></p>
+            <p class="mx-auto mb-3 mb-lg-4" style="max-width: 38em;">On 18th October 2023 we’ll be releasing the results of the Council Climate Action Scorecards, scoring the actual climate action they have taken. We published our draft methodology for the the Council Climate Action Scorecards 2023 in November 2022, and the final version is now available:</p>
+            <p><a href="{% url 'methodology' %}" class="btn btn-blue is--light">Read the 2023 methodology</a></p>
             <a href="{% url 'methodology' %}" class="d-none d-sm-block my-4 my-lg-5"><img src="{% static 'scoring/img/2023-timeline@2x.png' %}" width="700" height="150" style="max-width: 100%; height: auto;" class="d-block mx-auto" alt="Timeline showing: April to August 2022, research and development; July to September 2022, one-to-one and sector-wide consultations; November to December 2022, publish finalised metrics for Scorecards; February to March 2023, first marking with volunteers; April to May 2023, five week right of reply period; Summer 2023, scoring audit; and 18th October 2023, scorecards launch"></a>
             <p class="mx-auto mb-3"><a href="https://www.climateemergency.uk/" class="d-inline">Join our mailing list</a> to follow our progress towards the 2023 Scorecards.</p>
             <p class="mx-auto mb-0">If you want to volunteer to help create the Council Climate Action Scorecards find out more <a href="https://actionnetwork.org/forms/application-scorecards-volunteering/" class="d-inline">here</a>.</p>

--- a/scoring/templates/scoring/methodology2023.html
+++ b/scoring/templates/scoring/methodology2023.html
@@ -6,7 +6,7 @@
             <div class="bg-dark-grey">
                 <div class="container-xl hero">
                     <a class="cta reverse white" href="{% url 'home' %}">Back to the Scorecards</a>
-                    <h1 class="text-white mt-3">Draft Methodology</h1>
+                    <h1 class="text-white mt-3">2023 Methodology</h1>
                     <div class="mt-3">
                         <span class="hero-sub">Council Climate Action Scorecards</span>
                     </div>
@@ -28,8 +28,8 @@
                             <a class="list-group-item text-decoration-none" href="#section-question-weighting-within">Question weighting within sections</a>
                             <a class="list-group-item text-decoration-none" href="#section-what-will-we-be-marking">What will we be marking?</a>
                             <a class="list-group-item text-decoration-none" href="#section-developing-the-scoring-system">Developing the scoring system</a>
-                            <a class="list-group-item text-decoration-none" href="#section-why-sections">Why these sections?</a>
-                            <a class="list-group-item text-decoration-none" href="#section-why-weightings">Why these weightings?</a>
+                            <a class="list-group-item text-decoration-none" href="#section-scoring-process">Scoring process</a>
+                            <a class="list-group-item text-decoration-none" href="#section-why-weightings">Scorecard sections summary and weighting</a>
                             <a class="list-group-item text-decoration-none" href="#section-further-info">Further info</a>
                             <a class="list-group-item text-decoration-none" href="#section-thank-you">Thank you</a>
                         </nav>
@@ -44,24 +44,20 @@
 
                     <h2 id="section-summary" class="mb-3">Summary</h2>
 
-                    <p>We have now published the draft methodology for the Council Climate Action Scorecards. This lays out how we'll be marking and scoring all UK councils on the actions they’re taking towards net zero. The Council Climate Action Scorecard results will be released in Autumn 2023.</p>
-                    <p>We will mark and score all UK councils on their climate action against 89 questions in 7 different sections. We created the criteria through extensive research and consultation with council staff, councillors, campaigners and other organisations. To understand what action we will be scoring and the question weightings, please read the complete draft methodology here. To find out more about how we created each section and why questions or topics were or were not included, <a class="d-inline" href="https://www.climateemergency.uk/draft-methodology-blog-series/">check out our blog series on the draft methodology here</a>.</p>
-                    <p>Whilst every effort has been made to make this methodology complete, <strong>Climate Emergency UK reserves the right to make changes to the methodology where deemed appropriate between now and Autumn 2023.</strong> Changes may be made, for example, if national policy changes between now and Autumn 2023 and this impacts our questions; or if the data needed to answer a particular question is no longer available to use. An updated methodology, identical to the one used in the marking, will be published, if needed, alongside the Council Climate Action Scorecards in Autumn 2023.</p>
-                    <p><strong>The Council Climate Action Scorecards is a project of Climate Emergency UK, with technical support from <a class="d-inline" href="https://www.mysociety.org/">mySociety</a></strong>.</p>
+                    <p>This is the methodology for the Council Climate Action Scorecards, which was published as a draft in November 2022 and a final version was published in October 2023. This lays out how we have marked and scored all UK councils on the actions they’ve taken towards net zero.</p>
+                    <p>We have marked and scored all UK councils on their climate action against 91 questions in 7 different sections. We created the criteria through extensive research and consultation with council staff, councillors, campaigners and other organisations. To understand what action we are scoring and the question weightings, please read below. To find out more about how we created each section and why questions or topics were or were not included, check out <a href="https://www.climateemergency.uk/draft-methodology-blog-series/">our blog series on the draft methodology here</a>.</p>
+                    <p>The finalised methodology is what was used to assess councils in the 2023 Council Climate Action Scorecards. Compared to the draft methodology that was published in November 2022, there have been some minor changes. These changes include adding in two new questions to the transport section for single-tier and district councils, completing the criteria for a couple of questions and a handful of minor clarifications elsewhere.</p>
+                    <p>The Council Climate Action Scorecards is a project of Climate Emergency UK, with technical support from <a href="https://www.mysociety.org/">mySociety</a>.</p>
 
-                    <div class="alert alert-warning mt-4 mt-lg-5 bg-grey border" role="alert">
-                        <h2 class="h5">Get this information in alternative formats</h2>
-                        <p>The explanatory content of this page is available as a PDF:</p>
-                        <a href=" https://drive.google.com/file/d/1bceKBGSK_cbEulsNvOTtvFPlWGcrA840/view?usp=sharing" class="btn btn btn-blue is--light mr-2 mb-3 mb-sm-4">Explanatory content (PDF)</a>
-                        <p>The questions and criteria are available in two additional formats:</p>
-                        <a href=" https://drive.google.com/file/d/1ntX3GqwmwPPVjrf9ZkNQmMrNac0yr731/view?usp=sharing" class="btn btn btn-blue is--light mr-2">Questions (PDF)</a>
-                        <a href="https://docs.google.com/spreadsheets/d/1DCn4ZwqALg5L3BUcDwuBmudPZghisQMjshIgl3JoGYM/edit?usp=sharing" class="btn btn btn-blue is--light mt-2 mt-sm-0 mr-2">Questions (Spreadsheet)</a>
+                    <div class="alert alert-primary">
+                        <p class="mb-0">If you’re interested in volunteering with us, to support others to use the Action Scorecards or help us mark the next Action Scorecards, <a href="https://actionnetwork.org/forms/volunteer-with-climate-emergency-uk/">register your interest here</a>.</p>
                     </div>
+
 
                     <h2 id="section-question-criteria" class="mt-5 mb-3">Question criteria</h2>
 
-                    <p>Below you can see each of the questions that councils will be scored on in 2023, along with some further clarification of the question criteria. We’ve also shown how each question will be scored: whether from volunteer research, FOI responses from councils, the use of national data or through a mixture of volunteer research and national data. <strong>Unless otherwise stated, we are marking council climate action from 1st January 2019</strong> up until March 2023 (exact date to be confirmed). For questions that use national data we will take the most recent data up until 1st August 2023. For questions that use FOI requests, unless otherwise stated, we are marking council climate action from 1st January 2019 up until January 2023 when the FOI requests will be sent out. Strategies and Policies that we mark must also be in date and active (except for Local Plans where draft ones will be accepted).</p>
-                    <p>Different council types have different powers. Therefore, questions are only being asked to a council where they have power or influence on that topic. For example, County Councils are not Planning Authorities so there are only two questions in the Planning section that apply to County Councils. To understand more about the different powers that different councils have, <a class="d-inline" href="https://www.instituteforgovernment.org.uk/explainers/local-government">check out this blog from the Institute of Governance.</a><strong>This is why, sometimes, you will see, for example, questions 1, 2, and 4 but not question 3, as question 3 doesn’t apply to the council you have selected.</strong></p>
+                    <p>Below you can see each of the questions that councils have been scored on in 2023, along with some further clarification of the question criteria. We’ve also shown how each question will be scored: whether from volunteer research, FOI responses from councils, the use of national data or through a mixture of volunteer research and national data. <strong>Unless otherwise stated, we are marking council climate action from 1st January 2019 up until 31st March 2023</strong>. For questions that use national data we will take the most recent data up until 1st August 2023. For questions that use FOI requests, unless otherwise stated, we are marking council climate action from 1st January 2019 up until January 2023 when the FOI requests will be sent out. We have accepted FOI responses up until 31st July 2023. Strategies and Policies that we mark must also be in date and active (except for Local Plans where drafts have been accepted).</p>
+                    <p>Different council types have different powers. Therefore, questions are only asked to a council where they have power or influence on that topic. For example, county councils are not Planning Authorities so there are only two questions in the Planning section that apply to county councils. To understand more about the different powers that different councils have, <a href="https://www.instituteforgovernment.org.uk/explainers/local-government">check out this blog from the Institute for Government</a>. <strong>This is why, sometimes, you will see, for example, questions 1, 2, and 4 but not question 3, as question 3 doesn’t apply to the council you have selected</strong>.</p>
 
                     <h3 class="mt-5 mb-3"><span class="underline-green">See the questions</span></h3>
 
@@ -185,7 +181,8 @@
 
                         <h3 class="mt-5 mb-3"><span class="underline-green">Combined Authorities</span></h3>
 
-                        <p>Combined authorities have quite different powers and responsibilities to other council structures. This is why there are fewer sections and questions for combined authorities. Of all the questions for combined authorities, just under half of these questions are the same as for other council types. The remaining questions are only applicable to combined authorities, of which some of these questions are similar to questions being asked of other council types. You can read <a href="https://www.climateemergency.uk/draft-methodology-blog-series/">our blog listed here</a> for further information on how combined authority powers differ to other council types and why we created the combined authority methodology the way we did.</p>
+                        <p>This methodology is identical to the one used in the marking of the Council Climate Action Scorecards in Autumn 2023. Compared to the draft methodology that was published in February 2023 for combined authorities, there have been some minor changes, such as defining the criteria for questions 9a and 9b in Buildings, Heating and Green Skills and other minor clarifications.</p>
+                        <p>Combined authorities have quite different powers and responsibilities to other council structures. This is why there are fewer sections and questions for combined authorities. Of all the questions for combined authorities, just under half of these questions are the same as for other council types. The remaining questions are only applicable to combined authorities, of which some of these questions are similar to questions being asked of other council types. <a href="https://www.climateemergency.uk/draft-methodology-blog-series/">You can read our blog listed here</a> for further information on how combined authority powers differ to other council types and why we created the combined authority methodology the way we did. </p>
 
                         <h2 id="section-weightings" class="mt-5 mb-3">Section weightings</h2>
 
@@ -252,7 +249,8 @@
                             </tbody>
                         </table>
 
-                        <h3 class="mt-4 mt-sm-5 mb-3">Section weightings for Combined Authorities </h3>
+                        <h3 class="mt-4 mt-sm-5 mb-3"><span class="underline-green">Section weightings for Combined Authorities</span></h3>
+
                         <table class="minimal-table" style="max-width: 25em">
                             <thead>
                                 <tr class="bg-green">
@@ -284,51 +282,187 @@
                             </tbody>
                         </table>
 
-                        <h2 id="section-question-weighting-within" class="mt-5 mb-3">Question weighting within sections</h2>
-
-                        <p>This draft methodology does not show the exact number of points allocated for each question. These will be published alongside the results of the Council Climate Action Scorecards in Autumn 2023.</p>
-                        <p>At this stage, you can see an indication as to which questions will be worth more points than others, shown as low, medium, or high importance. All of the actions that we are marking in our Scorecard questions are important: all of these actions will reduce greenhouse gas emissions and are actions that we want to see councils undertake, but within this, there are some actions that have a bigger and more direct impact on reducing emissions.</p>
-                        <p>The questions that are weighted high are those which we consider to have the biggest impact on greenhouse gas emission reductions and a sustained long-term impact. For example, low emission policies implemented in Local Plans will have a huge impact on all new homes built over the next 10 years. Questions that are also key to enabling climate actions for councils are weighted high, such as whether they are finding finance for their climate actions or whether they have an annual Climate Action Plan Update.</p>
-                        <p>Areas of action where the impact on greenhouse gas emissions is one step removed, or where the impact on emissions is reliant on other actors and actions, such as the national UK Government and devolved assemblies, are marked as medium.</p>
-                        <p>For example, employing a retrofit officer is a really important action that councils can take, but this action alone won’t reduce greenhouse gas emissions from homes and buildings. It’s the work that this person will do, with other actors and funding that will lead to emission reductions. Another example is recycling; whilst councils can have a big role in improving recycling rates, it is also dependent on residents’ behaviour, national policy and how supermarkets package their food.</p>
-                        <p>Questions that are weighted low include all actions which relate solely to the councils’ own activities. These questions include: changing council processes to be more climate friendly; actions where councils have limited direct influence; and actions that are about the climate action strength of written strategies and plans. This is because council-only greenhouse gas emissions are a tiny part of an area’s overall emissions, between 2% and 7%. </p>
-                        <p>These Scorecards focus on action, so whilst there is benefit in us scoring the strength of written plans, this too is weighted low. For the Planning section, we are scoring the strength of a councils’ Local Plan and for this section, questions measuring the strength of their written Local Plan have been given low, medium and high weightings. This is because we recognise that sustainability requirements in a Local Plan are a significant change in policy. </p>
-                        <p>There are also some questions that will be scored negatively: councils will lose marks if they have taken actions that actively increase greenhouse gas emissions reduction. There are a total of three negatively scoring questions, found in the Transport, Governance &amp; Finance and Planning sections.</p>
-
                     </div>
 
-                    <h2 id="section-what-will-we-be-marking" class="mt-5 mb-3">What will we be marking?</h2>
+                    <h2 id="section-question-weighting-within" class="mt-5 mb-3">Question weighting within sections</h2>
+
+                    <p>The question weighting determines the importance of that question to the overall section score. All questions in the Action Scorecards are out of a number of marks, ranging from 1 to 6, as well as some questions where penalty points are awarded and councils lose marks (more on penalty marks below). This is the raw mark for each question.</p>
+                    <p>To ensure appropriate weighting to each question, each raw score for a question has been translated into a score out of one, two or three, depending on whether the question is weighted low (one), medium (two) or high (three). We have converted each raw mark into the equivalent fraction out of one, two or three. For example, if a question is out of 4 raw marks and the question is weighted as high, then if a council scores 2 out of 4, their weighted score would be 1.5 out of 3. If a council had scored 1 out of 4, their weighted score would be 0.75 out of 3. More on how we calculated the final scores here. </p>
+                    <p>All questions in the Action Scorecards are weighted low, medium or high (except the penalty mark questions and question 2 in Transport, which receives one point for every option).</p>
+
+                    <h3 class="mt-4 mt-sm-5 mb-3"><span class="underline-green">Why do you have Question Weighting?</span></h3>
+
+                    <p>All of the actions that we are marking in our Scorecard questions are important: all of these actions will reduce greenhouse gas emissions and are actions that we want to see councils undertake, but within this, there are some actions that have a bigger and more direct impact on reducing emissions.</p>
+                    <p>The questions that are weighted high are those which we consider to have the biggest impact on greenhouse gas emission reductions and a sustained long-term impact. For example, low emission policies implemented in Local Plans will have a huge impact on all new homes built over the next 10 years. Questions that are also key to enabling climate actions for councils are weighted high, such as whether they are finding finance for their climate actions or whether they have an annual Climate Action Plan Update.</p>
+                    <p>Areas of action where the impact on greenhouse gas emissions is one step removed, or where the impact on emissions is reliant on other actors and actions, such as the national UK Government and devolved assemblies, are marked as medium.</p>
+                    <p>For example, employing a retrofit officer is a really important action that councils can take, but this action alone won’t reduce greenhouse gas emissions from homes and buildings. It’s the work that this person will do, with other actors and funding that will lead to emission reductions. Another example is recycling; whilst councils can have a big role in improving recycling rates, it is also dependent on residents’ behaviour, national policy and how supermarkets package their food.</p>
+                    <p>Questions that are weighted low include all actions which relate solely to the councils' own activities. These questions include: changing council processes to be more climate friendly; actions where councils have limited direct influence; and actions that are about the climate action strength of written strategies and plans. This is because council-only greenhouse gas emissions are a tiny part of an area’s overall emissions, between 2% and 7%.</p>
+                    <p>These Scorecards focus on action, so whilst there is benefit in us scoring the strength of written plans, this too is weighted low. For the Planning section, we are scoring the strength of a councils’ Local Plan and for this section, questions measuring the strength of their written Local Plan have been given low, medium and high weightings. This is because we recognise that sustainability requirements in a Local Plan are a significant change in policy. </p>
+
+                    <h3 id="penalty-marks" class="mt-4 mt-sm-5 mb-3"><span class="underline-green">Penalty Marks</span></h3>
+
+                    <p>There are four questions where councils can receive penalty marks and they lose marks. These are questions where the action that a council has taken is contributing to higher carbon emissions. Where a council has been awarded the penalty mark, the penalty mark is a percentage reduction of the maximum possible score for this section. This is how all penalty marks are calculated for all councils types and all penalty mark questions, except for county councils for Question 11 in Planning and Land Use. For this question, the penalty marks for county councils is up to 4.5 points (equivalent to the penalty mark percentage deduction for single-tier authorities) to be taken off their total section score. This has been done this way because the maximum number of raw marks county councils can be awarded in this section is 3 and approving fossil fuel infrastructure, such as new oil drilling or a coal mine has a major effect on increasing emissions.</p>
+                    <p>These penalty marks only apply in three sections: Transport, Governance & Finance and Planning and Land Use. Not all of the penalty mark questions apply to all council types, due to the difference in council powers.</p>
+                    <p>You can see below which questions carry penalty marks, which council types these questions apply to and the penalty mark awarded.</p>
+
+                    <table class="minimal-table text-start">
+                        <thead>
+                            <tr class="d-none d-lg-table-row bg-green">
+                                <th scope="col" class="w-15">Section</th>
+                                <th scope="col" class="w-10">Question number</th>
+                                <th scope="col">Question</th>
+                                <th scope="col">Applies to</th>
+                                <th scope="col">Penalty Mark: percentage reduction from the maximum possible section score</th>
+                                </tr>
+                        </thead>
+                        <tbody>
+                            <tr class="d-flex flex-column d-lg-table-row mb-3 mb-lg-0">
+                                <td>
+                                    <span class="d-block text-muted font-weight-bold d-lg-none me-1">section</span>
+                                    Transport
+                                </td>
+                                <td><span class="d-block text-muted font-weight-bold d-lg-none me-1">Question number</span>11a</td>
+                                <td><span class="d-block text-muted font-weight-bold d-lg-none me-1">Question</span>Has the council approved, expanded or built a high carbon transport project since 2019?</td>
+                                <td><span class="d-block text-muted font-weight-bold d-lg-none me-1">Applies to</span>
+                                    Single tier,
+                                    District,
+                                    County,
+                                    Northern Irish councils
+                                </td>
+                                <td><span class="d-block d-lg-none fw-bold mb-2">Penalty Mark: percentage reduction from the maximum possible section score</span>
+                                    Penalty mark of -5% for roads<BR><BR>
+                                    Penalty mark of -15% for airports<BR><BR>
+                                    Total penalty mark of -20%
+                                </td>
+                            </tr>
+                            <tr class="d-flex flex-column d-lg-table-row mb-3 mb-lg-0">
+                                <td>
+                                    <span class="d-block text-muted font-weight-bold d-lg-none me-1">section</span>
+                                    Transport
+                                </td>
+                                <td><span class="d-block text-muted font-weight-bold d-lg-none me-1">Question number</span>1a</td>
+                                <td><span class="d-block text-muted font-weight-bold d-lg-none me-1">Question</span>Does the combined authority’s Transport Plan include expanding or building a high carbon transport project?</td>
+                                <td><span class="d-block text-muted font-weight-bold d-lg-none me-1">Applies to</span>Combined authorities</td>
+                                <td><span class="d-block d-lg-none fw-bold mb-2">Penalty Mark: percentage reduction from the maximum possible section score</span>
+                                    Penalty mark of -5% for roads<BR><BR>
+                                    Penalty mark of -15% for airports<BR><BR>
+                                    Total penalty mark of -20%
+                                </td>
+                            </tr>
+                            <tr class="d-flex flex-column d-lg-table-row mb-3 mb-lg-0">
+                                <td>
+                                    <span class="d-block text-muted font-weight-bold d-lg-none me-1">section</span>
+                                    Transport
+                                </td>
+                                <td><span class="d-block text-muted font-weight-bold d-lg-none me-1">Question number</span>12a</td>
+                                <td><span class="d-block text-muted font-weight-bold d-lg-none me-1">Question</span>Do the NO2 levels in a significant proportion of neighbourhoods within the council’s area exceed the safe World Health Organisation (WHO) air pollution guidelines?</td>
+                                <td><span class="d-block text-muted font-weight-bold d-lg-none me-1">Applies to</span>Single tier &
+                                    District
+                                </td>
+                                <td><span class="d-block d-lg-none fw-bold mb-2">Penalty Mark: percentage reduction from the maximum possible section score</span>
+                                    Lower Tier: -2% of maximum possible section score.
+                                    Higher Tier:<BR><BR>
+                                    -6% of maximum possible section score.<BR><BR>
+                                    Total negative score is -6%
+                                </td>
+                            </tr>
+                            <tr class="d-flex flex-column d-lg-table-row mb-3 mb-lg-0">
+                                <td>
+                                    <span class="d-block text-muted font-weight-bold d-lg-none me-1">section</span>
+                                    Transport
+                                </td>
+                                <td><span class="d-block text-muted font-weight-bold d-lg-none me-1">Question number</span>12b</td>
+                                <td><span class="d-block text-muted font-weight-bold d-lg-none me-1">Question</span>Do the PM 2.5 levels in a significant proportion of neighbourhoods in the council’s area exceed the safe World Health Organisation (WHO) air pollution guidelines?</td>
+                                <td><span class="d-block text-muted font-weight-bold d-lg-none me-1">Applies to</span>Single tier,
+                                    District
+                                </td>
+                                <td><span class="d-block d-lg-none fw-bold mb-2">Penalty Mark: percentage reduction from the maximum possible section score</span>
+                                    Lower Tier: -2% of maximum possible section score.
+                                    Higher Tier:<BR><BR>
+                                    -4% of maximum possible section score.<BR><BR>
+                                    Total negative score is -4%
+                                </td>
+                            </tr>
+                            <tr class="d-flex flex-column d-lg-table-row mb-3 mb-lg-0">
+                                <td>
+                                    <span class="d-block text-muted font-weight-bold d-lg-none me-1">section</span>
+                                    Governance & Finance
+                                </td>
+                                <td><span class="d-block text-muted font-weight-bold d-lg-none me-1">Question number</span>12</td>
+                                <td><span class="d-block text-muted font-weight-bold d-lg-none me-1">Question</span>Does the council have direct investments in airports or high carbon intensive energy industries?</td>
+                                <td><span class="d-block text-muted font-weight-bold d-lg-none me-1">Applies to</span>Single tier,
+                                    District,
+                                    County,
+                                    Northern Irish councils
+                                </td>
+                                <td><span class="d-block d-lg-none fw-bold mb-2">Penalty Mark: percentage reduction from the maximum possible section score</span>
+                                    Penalty mark of - 15% for direct investments in airports or high carbon intensive energy industries.
+                                </td>
+                            </tr>
+                            <tr class="d-flex flex-column d-lg-table-row mb-3 mb-lg-0">
+                                <td>
+                                    <span class="d-block text-muted font-weight-bold d-lg-none me-1">section</span>
+                                    Planning
+                                </td>
+                                <td><span class="d-block text-muted font-weight-bold d-lg-none me-1">Question number</span>11</td>
+                                <td><span class="d-block text-muted font-weight-bold d-lg-none me-1">Question</span>Has the Council approved a planning application for a carbon intensive energy system to be built or expanded from 2019?</td>
+                                <td><span class="d-block text-muted font-weight-bold d-lg-none me-1">Applies to</span>Single tier,
+                                    County councils
+                                </td>
+                                <td><span class="d-block d-lg-none fw-bold mb-2">Penalty Mark: percentage reduction from the maximum possible section score</span>
+                                    Penalty mark of -20% for Single tier councils<BR><BR>
+                                    Penalty mark of -4.5 points for county councils (equivalent to the penalty mark for single-tier authorities)
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+
+                    <h3 class="mt-5 mb-3"><span class="underline-green">Calculating the final score</span></h3>
+
+                    <p>There are four stages to creating the final score.</p>
+
+                    <ol>
+                        <li>Raw marks are converted into low, medium and high weighted marks.</li>
+                        <li>Penalty marks are deducted where councils have received them.</li>
+                        <li>Total weighted marks are added up and converted into an overall percentage score for each section.</li>
+                        <li>The final score is created from adding up the overall section scores and applying the section weighting. For example, receiving a 50% score in Collaboration & Engagement equals 5% of a council’s overall score. This is because Collaboration & Engagement is worth 10% of a council's overall score.</li>
+                    </ol>
+
+                    <h2 id="section-what-will-we-be-marking" class="mt-5 mb-3">What We Marked</h2>
 
                     <h3 class="mt-4 mb-2 mb-lg-3"><span class="underline-green">Publicly available council information</span></h3>
 
-                    <p>Unless stated otherwise in the question criteria, we will be scoring councils on any actions that they have taken since 1st January 2019 up until March 2023 (exact date to be confirmed soon). We chose this date because it was in 2019 that councils started declaring climate emergencies and we want to score councils on their action since this (renewed) commitment to climate action came into effect. </p>
-                    <p>For example, if a council approved a solar panel farm in 2017 and no further renewable energy since then, the council would not get a point for the relevant question here. This is because councils need to be taking consistent climate action, so we would expect councils to be consistently pursuing actions such as this since 1st January 2019.</p>
-                    <p>This does not entirely mean that councils’ scores won’t reflect action taken before 1st January 2019. For example, if a council worked hard to improve the EPC ratings of its council homes before 2019 through retrofitting and other insulation measures, then their average EPC ratings of these homes is likely to be higher, and they would therefore score higher for this particular question.</p>
-                    <p>Whilst these Scorecards focus on council action, there are some questions that look at the details of particular policies. When we look at policies and strategies, they must be in date. For example if a Local Plan is dated 2015-2025, then this will be scored.</p>
-                    <p>We will be looking for evidence that is publicly available. When we start marking in the new year, we will be looking at a wide variety of documents. Documents where this evidence might be available that we will consider when marking includes, but is not limited to:</p>
+                    <p>Unless stated otherwise in the question criteria, we scored councils on any actions that they have taken since 1st January 2019 up until 31st March 2023. We chose this date because it was in 2019 that councils started declaring climate emergencies and we want to score councils on their action since this (renewed) commitment to climate action came into effect. </p>
+                    <p>For example, if a council approved a solar panel farm in 2017 and no further renewable energy since then, the council would not get a point for the relevant question here. This is because councils need to be taking consistent climate action, so we expect councils to be consistently pursuing actions such as this since 1st January 2019.</p>
+                    <p>This does not entirely mean that councils' scores do not reflect action taken before 1st January 2019. For example, if a council worked hard to improve the EPC ratings of its council homes before 2019 through retrofitting and other insulation measures, then their average EPC ratings of these homes is likely to be higher, and they would therefore score higher for this particular question.</p>
+                    <p>Whilst these Scorecards focus on council action, there are some questions that look at the details of particular policies. When we look at policies and strategies, they must be in date. For example if a Local Plan is dated 2015-2025, then this is scored.
+                    </p>
+                    <p>We look for evidence that is publicly available across a wide variety of documents. Documents where this evidence might be available that we consider when marking includes, but is not limited to:</p>
 
                     <div class="row mt-n2">
                         <div class="col-lg-6">
-                            <h5 class="mt-3 mt-sm-4">(Used across all sections)</h5>
+                            <h4 class="mt-3 mt-sm-4">(Used across all sections)</h4>
                             <ul>
                                 <li>News stories on council websites</li>
                                 <li>News stories in local media</li>
+                                <li>Climate Action Plans</li>
                                 <li>Climate Action Plan Updates</li>
                                 <li>Climate sections of council websites</li>
                             </ul>
 
-                            <h5 class="mt-3 mt-sm-4">Buildings &amp; Heating</h5>
+                            <h4 class="mt-3 mt-sm-4">Buildings &amp; Heating</h4>
                             <ul>
                                 <li>Housing strategies</li>
                                 <li>Fuel poverty strategies</li>
+                                <li>Home Energy Conservation Report (HECA)</li>
                             </ul>
 
-                            <h5 class="mt-3 mt-sm-4">Transport</h5>
+                            <h4 class="mt-3 mt-sm-4">Transport</h4>
                             <ul>
                                 <li>Transport strategy</li>
                             </ul>
 
-                            <h5 class="mt-3 mt-sm-4">Governance &amp; Finance</h5>
+                            <h4 class="mt-3 mt-sm-4">Governance &amp; Finance</h4>
                             <ul>
                                 <li>Corporate Plan</li>
                                 <li>Medium-term Financial Plan</li>
@@ -342,30 +476,29 @@
                             </ul>
                         </div>
                         <div class="col-lg-6">
-                            <h5 class="mt-3 mt-sm-4">Planning</h5>
+                            <h4 class="mt-3 mt-sm-4">Planning</h4>
                             <ul>
                                 <li>Local Plans and related documents</li>
                                 <li>Supplementary Planning documents</li>
                                 <li>Parking Standards</li>
                             </ul>
 
-                            <h5 class="mt-3 mt-sm-4">Biodiversity</h5>
+                            <h4 class="mt-3 mt-sm-4">Biodiversity</h4>
                             <ul>
                                 <li>Biodiversity strategy</li>
                                 <li>Tree strategy</li>
                                 <li>Local Plan or relevant Development Plan documents</li>
                             </ul>
 
-                            <h5 class="mt-3 mt-sm-4">Collaboration &amp; Engagement</h5>
+                            <h4 class="mt-3 mt-sm-4">Collaboration &amp; Engagement</h4>
                             <ul>
-                                <li>Climate Action Plan</li>
                                 <li>Climate public engagement strategies</li>
                                 <li>Joint Strategic Needs Assessment</li>
                                 <li>Health partnership pages</li>
                                 <li>Local Enterprise Partnership pages</li>
                             </ul>
 
-                            <h5 class="mt-3 mt-sm-4">Waste Reduction &amp; Food</h5>
+                            <h4 class="mt-3 mt-sm-4">Waste Reduction &amp; Food</h4>
                             <ul>
                                 <li>Waste strategies</li>
                                 <li>Food strategies</li>
@@ -377,18 +510,22 @@
 
                     <h3 class="mt-4 mb-2 mb-lg-3"><span class="underline-green">National data</span></h3>
 
-                    <p>For some of the questions, we are using external data, compiled by the UK Government, the Devolved Nations or other national non-governmental organisations. We are using this data for specific questions only and the use of this data is not an endorsement of the organisation or government body. Unless otherwise stated in the question criteria, we will use the most recent national data available up until 1st August 2023.</p>
+                    <p>For some of the questions, we use external data, compiled by the UK Government, the Devolved Nations or other national non-governmental organisations. We use this data for specific questions only and the use of this data is not an endorsement of the organisation or government body. Unless otherwise stated in the question criteria, we use the most recent national data available up until 1st August 2023.</p>
 
                     <h3 class="mt-4 mb-2 mb-lg-3"><span class="underline-green">Freedom of Information requests</span></h3>
 
-                    <p>You can see the current draft list of the FOI requests we plan to send <a href="https://drive.google.com/file/d/18ZCmVF2QYWeQcR2fpxL_UBkK8A9HHg6A/view?usp=sharing" class="d-inline">here</a>. 
-                        We will be sending FOI requests using WhatDoTheyKnow (run by mySociety). All FOI responses sent via <a class="d-inline" href="https://www.whatdotheyknow.com/">WhatDoTheyKnow</a> will be made public and linked to the Scorecards when published. Unless otherwise stated in the FOI request, we are marking council climate action from 1st January 2019 up until January 2023 when the FOI requests will be sent out.</p>
-                    <p>To find out more about how we created each section and why questions or topics were or were not included, check out our blog series on the draft methodology <a class="d-inline" href="https://www.climateemergency.uk/draft-methodology-blog-series/">here</a>.</p>
+                    <p>We sent FOI requests (technically sent as Environmental Information Regulations (EIR) requests) to all UK councils in January and February 2023 using <a href="https://www.whatdotheyknow.com/">WhatDoTheyKnow</a> (run by mySociety).  You can see the <a href="https://drive.google.com/file/d/1fH6QHJfLpbQ6YsrAEixPtPF5SaU4_yo_/view?usp=share_link">lists of FOI requests we sent here</a> and the <a href="https://www.whatdotheyknow.com/user/climate_emergency_uk" class="d-inline">responses can be viewed via WhatDoTheyKnow here</a>.</p>
+                    <p>Any response provided via WhatDoTheyKnow from a council is valid and was used for relevant Scorecard questions. If a council responded to all FOI requests in one response, this is valid. If a council responded to an FOI with a link to a portal to sign up or create a password  and view the response with a time limit, this  response wasn’t used. This is because the underlying principles of FOI/EIR requests is to make information freely and easily available and responding with information behind passwords or a time limit is not freely available.</p>
+                    <p>Volunteers were trained to read the FOI responses from councils and log the responses appropriately during the first mark.</p>
+                    <p>Councils were able to see their own FOI responses during the Right of Reply. A very small number of councils responded with information in the Right of Reply which was different to information we received via WhatDoTheyKnow. Where updated information was provided to us in the Right of Reply, we used the information provided in the Right of Reply, to award marks for the relevant questions in the scorecards. We also annotated the original FOIs with this updated information, which can be seen on the relevant FOIs WhatDoTheyKnow.</p>
+                    <p>FOI responses and responses from councils provided in the Right of Reply were then reviewed as part of the audit when awarding the final score. </p>
+                    <p>To find out more about how we created each section and why questions or topics were or were not included, check out <a href="https://climateemergency.org.uk/draft-methodology-blog-series/">our blog series on the draft methodology here</a>. </p>
+
 
                     <h3 class="mt-4 mb-2 mb-lg-3"><span class="underline-green">Councils that are changing structures</span></h3>
 
-                    <p>A small number of councils will be changing structure and forming new council structures from 1st April 2023. Following consultations with the councils that this affects we have decided that, where this is the case, the old and new councils will not be scored in the 2023 Scorecards. The new council will be scored in future Scorecards as normal.</p>
-                    <p>To ensure complete transparency we will include the new council names on the relevant Scorecard results lists, with a note explaining why this council has not been scored this year.</p>
+                    <p>A small number of councils changed structure and formed new council structures from 1st April 2023. Following consultations with the councils that this affects we decided that, where this is the case, the old and new councils have not been scored in the 2023 Scorecards. The new council will be scored in future Scorecards as normal.</p>
+                    <p>To ensure complete transparency we include the new council names on the relevant Scorecard results lists, with a note explaining why this council has not been scored this year.</p>
 
                     <h2 id="section-developing-the-scoring-system" class="mt-5 mb-3">Developing the scoring system</h2>
 
@@ -417,12 +554,12 @@
                         <li>Davila Coolen (Environmental Engineering background and former CE UK Scorecard volunteer)</li>
                         <li>Mandi Bissett (sustainability consultant and former CE UK Scorecard volunteer)</li>
                         <li>Alex Parsons (mySociety data expert)</li>
+                        <li>Kiran Crawford (former CE UK volunteer)</li>
                     </ul>
                     <p class="mt-3 mt-lg-4">A final, complete review of the draft methodology was conducted by the Advisory group, along with:</p>
                     <ul>
                         <li>Kooj Chuhan (Crossing Footprints)</li>
                         <li>Caroline George (London Environment Directors’ Network)</li>
-                        <li>Kiran Crawford (former and current CE UK volunteer)</li>
                         <li>Natalia Kotowska (former and current CE UK volunteer)</li>
                         <li>Climate Change Manager at Leicester City Council</li>
                     </ul>
@@ -437,53 +574,65 @@
                     <p>Staff conducted a trial mark on a select number of councils to test the draft questions. Following this, a volunteer trial mark was also carried out to further test the draft questions on a different, select number of councils.</p>
                     <p>A small number of Freedom of Information (FOI) requests were also sent out to a random selection of councils. This was important to learn how best to ask the FOI questions to create  the least amount of work for councils when responding and for us when collecting the data. The recipients were chosen at random in order to have a variety of council types in the trial. You can <a href="https://www.whatdotheyknow.com/user/climate_emergency_uk" class="d-inline">see all the trial FOI requests on WhatDoTheyKnow</a>. Please note that these are different to the final FOI requests included in the Scorecards methodology, and some trial FOI requests will not be  used this year.</p>
 
-                    <h2 id="section-why-sections" class="mt-5 mb-3">Why these sections?</h2>
+                    <h2 id="section-scoring-process" class="mt-5 mb-3">Scoring process</h2>
 
-                    <h3 class="mt-4"><span class="underline-green">Buildings &amp; Heating</span></h3>
-                    <p class="mt-2">Buildings and Heating is one of the biggest sectors of carbon and other greenhouse gas emissions in the UK. This section aims to cover the main actions that councils can take to support both private rented and owned homes and socially renting households to reduce the emissions from their homes.</p>
+                    <h3 class="mt-4"><span class="underline-green">First Mark</span></h3>
+                    <p>A team of 215 trained volunteers marked all questions for all councils that were marked by volunteer research as shown in the methodology according to the question criteria. About two thirds of all of the Scorecard questions are marked by volunteer research. The first mark was conducted January to March 2023. </p>
 
-                    <h3 class="mt-4"><span class="underline-green">Transport</span></h3>
-                    <p class="mt-2">Transport is the other biggest sector of greenhouse gas emissions in the UK. This section covers the main enabling actions councils can take to reduce car use and encourage more sustainable transport within their area.</p>
+                    <h3 class="mt-4"><span class="underline-green">Right of Reply</span></h3>
+                    <p>All councils in the UK were sent their first mark for all questions marked by volunteer research and questions marked by FOI requests. Councils could see which questions had received marks, but they couldn’t see individual scores for questions or their overall score. All councils were given a right of reply. Councils had five weeks to respond and highlight any mistakes in the first mark  during April and May 2023. 74% of all UK councils responded to the Right of Reply in 2022. </p>
 
-                    <h3 class="mt-4"><span class="underline-green">Governance &amp; Finance</span></h3>
-                    <p class="mt-2">This section aims to understand to what extent climate action has been incorporated and embedded across the whole of the council in all its activities and services in its decision making, forward planning and structures. This section also looks at how councils are raising funds for climate action and whether the councils’ investments are sustainable or supporting high carbon infrastructure and industries.</p>
+                    <h3 class="mt-4"><span class="underline-green">Scoring Audit</span></h3>
+                    <p>During the scoring audit a team of around 50 highly trained volunteers and CE UK staff reviewed the first mark alongside the council's right of reply. All plans were audited regardless of whether the council responded to the right of reply. National data was also inputted into the Scorecards to create the final score. </p>
 
-                    <h3 class="mt-4"><span class="underline-green">Planning</span></h3>
-                    <p class="mt-2">This section focuses primarily on how councils are using their planning powers, primarily through their Local Plans, to ensure low emission new buildings and homes, as well as ensuring new developments are built to minimise their environmental impact. This section also covers the renewable energy generation and fossil fuel generation planning applications in the area.</p>
+                    <h2 id="section-why-weightings" class="mt-5 mb-3">Scorecard sections summary and weighting</h2>
 
-                    <h3 class="mt-4"><span class="underline-green">Biodiversity</span></h3>
-                    <p class="mt-2">The climate emergency is deeply connected to the ecological emergency. This section looks at what councils can do to protect and increase biodiversity in the area through their direct actions, the management of their green spaces, and biodiversity net gain requirements for developers. </p>
+                    <h3 class="mt-4 mb-3"><span class="underline-green">Sections Summary</span></h3>
+                    <h4>Buildings &amp; Heating</h4>
+                    <p>Buildings and Heating is one of the biggest sectors of carbon and other greenhouse gas emissions in the UK. This section covers the main actions that councils can take to support both private rented and owned homes and socially renting households to reduce the emissions from their homes. </p>
 
-                    <h3 class="mt-4"><span class="underline-green">Collaboration &amp; Engagement</span></h3>
-                    <p class="mt-2">This section addresses how councils can collaborate with others to improve their own climate action and to support others in the area to decarbonise. More than half of the emissions cuts needed to reach net zero rely on people and businesses taking up low-carbon solutions, and councils can work with those in their local area to enable those solutions.</p>
+                    <h4>Transport</h4>
+                    <p>Transport is the other biggest sector of greenhouse gas emissions in the UK. This section covers the main enabling actions councils can take to reduce car use and encourage more sustainable transport within their area. </p>
 
-                    <h3 class="mt-4"><span class="underline-green">Waste Reduction &amp; Food</span></h3>
-                    <p class="mt-2">This section looks at the influencing role councils can play in supporting sustainable food production on their land and in their schools, and circular economy initiatives locally. Councils also have an important role to play in waste and recycling locally and improving this. </p>
+                    <h4>Governance &amp; Finance</h4>
+                    <p>This section aims to understand to what extent climate action has been incorporated and embedded across the whole of the council in all its activities and services in its decision making, forward planning and structures. This section also looks at how councils are raising funds for climate action and whether the councils’ investments are sustainable or supporting high carbon infrastructure and industries.</p>
 
-                    <h2 id="section-why-weightings" class="mt-5 mb-3">Why these weightings?</h2>
+                    <h4>Planning and Land Use</h4>
+                    <p>This section focuses primarily on how councils are using their planning powers, primarily through their Local Plans, to ensure low emission new buildings and homes, as well as ensuring new developments are built to minimise their environmental impact. This section also covers the renewable energy generation and fossil fuel generation planning applications in the area.</p>
 
-                    <p class="mt-2">Different sections have been weighted differently, and the reasons for this are explained below.</p>
+                    <h4>Biodiversity</h4>
+                    <p>The climate emergency is deeply connected to the ecological emergency. This section looks at what councils can do to protect and increase biodiversity in the area through their direct actions, the management of their green spaces, and biodiversity net gain requirements for developers. </p>
 
-                    <h3 class="mt-4"><span class="underline-green">Transport and Buildings &amp; Heating</span></h3>
+                    <h4>Collaboration &amp; Engagement</h4>
+                    <p>This section addresses how councils can collaborate with others to improve their own climate action and to support others in the area to decarbonise. More than half of the emissions cuts needed to reach net zero rely on people and businesses taking up low-carbon solutions, and councils can work with those in their local area to enable those solutions.</p>
+
+                    <h4>Waste Reduction &amp; Food</h4>
+                    <p>This section looks at the influencing role councils can play in supporting sustainable food production on their land and in their schools, and circular economy initiatives locally. Councils also have an important role to play in waste and recycling locally and improving this. </p>
+
+                    <h3 class="mt-4"><span class="underline-green">Section Weightings</span></h3>
+                    <p>Different sections have been weighted differently, and the reasons for this are explained below.</p>
+
+                    <h4>Transport, and Buildings &amp; Heating</h4>
                     <p class="mt-2">These are the areas where councils can have the biggest impact on area wide greenhouse gas emissions. It is also where single tier councils can take the most effective action to reduce emissions; therefore they have been given the highest weighting. County councils have more powers over transport than district councils, which is why this section is weighted higher for county councils and a lot lower for district councils. </p>
 
-                    <h3 class="mt-4"><span class="underline-green">Planning &amp; Land Use and Governance &amp; Finance</span></h3>
-                    <p class="mt-2">These sections have a less direct impact on emissions reduction. However, they have a considerable impact on enabling climate action and embedding it in longer-term policies. All council types have similar power and responsibilities in Governance &amp; Finance and the actions scored in this section demonstrate the council’s commitment to reducing emissions and embedding climate action across the council. Planning &amp; Land Use is one of the areas where single tier and district councils can be the most effective and also hold a lot of power, both for mitigation and adaptation, hence the higher weighting here than for the final three sections. County councils are not planning authorities which explains their lower section weighting for the Planning &amp; Land Use section. </p>
+                    <h4>Planning &amp; Land Use, and Governance &amp; Finance</h4>
+                    <p class="mt-2">These sections have a less direct impact on emissions reduction. However, they have a considerable impact on enabling climate action and embedding it in longer-term policies. All council types have similar power and responsibilities in Governance &amp; Finance and the actions scored in this section demonstrate the council’s commitment to reducing emissions and embedding climate action across the council. Planning &amp; Land Use is one of the areas where single tier and district councils can be the most effective and also hold a lot of power, both for mitigation and adaptation, hence the higher weighting here than for the final three sections. County councils are not planning authorities which explains their lower section weighting for the Planning section.</p>
 
-                    <h3 class="mt-4"><span class="underline-green">Collaboration &amp; Engagement, Biodiversity and Waste Reduction &amp; Food</span></h3>
-                    <p class="mt-2">For these sections all councils have the same section weightings. This is because, while still vital, the actions scored in these three sections have the lowest direct impact on emission reduction, and within them, all council types have similar powers in relation to what they can influence. It is also harder to assess the effective engagement and communication of a council, and typically councils that effectively engage their residents will have more buy-in and be able to be more ambitious, so they will be able to score more elsewhere. </p>
+                    <h4>Collaboration &amp; Engagement, Biodiversity, and Waste Reduction &amp; Food</h4>
+                    <p class="mt-2">For these sections all councils have the same section weightings. This is because, while still vital, the actions scored in these three sections have the lowest direct impact on emission reduction, and within them, all council types have similar powers in relation to what they can influence. It is also harder to assess the effective engagement and communication of a council, and typically councils that effectively engage their residents will have more buy-in and be able to be more ambitious, so they will be able to score more elsewhere.</p>
                     <p>All councils have less powers over food. For biodiversity, waste reduction and food, a significant amount of actions and emissions are outside of councils’ control, so a lower weighting has been given to these sections to reflect this. This is not a reflection of the wider importance of biodiversity, food and waste to address the climate emergency. </p>
-                    <p>The powers that Northern Irish councils have are different to other nations. For example, Northern Irish councils have less control over Transport, Planning &amp; Land Use and Buildings &amp; Heating </p>
-                    <p>The powers that combined authorities have are different to other council types. For example, combined authorities have almost no power or responsibility for Waste Reduction &amp; Food, other than Manchester Combined Authority which works with other councils in the area as a waste collection authority (and the Greater London Authority and theWest Midlands Combined Authority play a small role in waste regionally too). In other areas, Combined Authorities have more power, funding and influence, such as in adult education and green skills which is why these questions have been added to the Buildings &amp; Heating section, making it the Buildings, Heating and Green Skills section. Combined Authorities have less power over new and existing buildings and their carbon emissions in an area hence changing the Buildings &amp; Heating questions to include more on Green Skills.</p>
+                    <p>The powers that Northern Irish councils have are different to other nations. For example, Northern Irish councils have less control over Transport, Planning &amp; Land Use and Buildings &amp; Heating, which is why the weightings for Northern Ireland are different. </p>
+                    <p>The powers that combined authorities have are different to other council types. For example, combined authorities have almost no power or responsibility for Waste Reduction &amp; Food, other than Manchester Combined Authority which works with other councils in the area as a waste collection authority (and the Greater London Authority and theWest Midlands Combined Authority play a small role in waste regionally too). In other areas, Combined Authorities have more power, funding and influence, such as in adult education and green skills which is why these questions have been added to the Buildings &amp; Heating section, making it the Buildings, Heating and Green Skills section. Combined Authorities have less power over new and existing buildings and their carbon emissions in an area hence changing the Buildings &amp; Heating questions to include more on Green Skills. </p>
 
                     <h2 id="section-further-info" class="mt-5 mb-3">Further info</h2>
 
-                    <p>To find out more about Climate Emergency UK please <a href="https://www.climateemergency.uk/" class="d-inline">visit our website</a>. You can also explore  the Council Climate Plan Scorecards from January 2023.</p>
+                    <p>To find out more about Climate Emergency UK please <a href="https://www.climateemergency.uk/" class="d-inline">visit our website</a>. You can also explore the Council Climate Plan Scorecards from January 2022.</p>
                     <p>If you have any further comments, questions or feedback <a href-"https://forms.gle/b5ezfQBcvT8hesv46" class="d-inline">please use our contact form here</a>.</p>
 
                     <h2 id="section-thank-you" class="mt-5 mb-3">Thank you</h2>
 
-                    <p>These Scorecards would not have been possible without the advice, comments and feedback from the many different organisations we spoke to, as well as our trial volunteer markers. Special thanks to mySociety, who have provided technical support in the creation of the Scorecard methodology. We also want to thank the many councillors and council staff we spoke to, who represented all council types and work across the four nations. Thank you also to the more than 90 different organisations we spoke to for comment and advice on the Scorecards, on specific questions, sections or general advice. The vast majority of the organisations we spoke to are listed here in alphabetical order. Thank you to:</p>
+                    <p>These Scorecards would not have been possible without the advice, comments and feedback from the many different organisations we spoke to, as well as our trial volunteer markers and most importantly our Scorecard volunteers assessors and auditors.</p>
+                    <p>Special thanks to mySociety, who have provided technical support in the creation of the Scorecard methodology. We also want to thank the many councillors and council staff we spoke to, who represented all council types and work across the four nations. Thank you also to the more than 90 different organisations we spoke to for comment and advice on the Scorecards, on specific questions, sections or general advice. The vast majority of the organisations we spoke to are listed here in alphabetical order. Thank you to:</p>
                     <ul class="mb-5" style="column-count: 2; column-gap: 40px;">
                         {% for organisation in organisations %}
                             <li>{{ organisation.name }}</li>

--- a/scoring/views.py
+++ b/scoring/views.py
@@ -564,7 +564,7 @@ class Methodology2023View(CheckForDownPageMixin, TemplateView):
         context[
             "all_councils"
         ] = Council.objects.all()  # for location search autocomplete
-        context["page_title"] = "Draft methodology"
+        context["page_title"] = "2023 Action Scorecards methodology"
         context["current_page"] = "methodology2023-page"
         context["sections"] = [
             {
@@ -1179,7 +1179,8 @@ class Methodology2023View(CheckForDownPageMixin, TemplateView):
                             <p class="mb-0">For this question the Clean Air Zone or Low Emission Zone does not have to require charges for private vehicles.</p>
                             """,
                         "clarifications": """
-                            <p class="mb-0">A Clean Air Zone or Low Emission Zone is where targeted action is being taken to improve air quality and reduce the number of polluting vehicles and is usually defined over a certain area, such as a city centre.</p>
+                            <p>A Clean Air Zone or Low Emission Zone is where targeted action is being taken to improve air quality and reduce the number of polluting vehicles and is usually defined over a certain area, such as a city centre.</p>
+                            <p class="mb-0">To be awarded points in the Scorecards the zone must be more than one street</p>
                             """,
                     },
                     {
@@ -1194,7 +1195,8 @@ class Methodology2023View(CheckForDownPageMixin, TemplateView):
                             <p class="mb-0">For this question the Clean Air Zone or Low Emission Zone does have to require charges for private vehicles.</p>
                             """,
                         "clarifications": """
-                            <p class="mb-0">A Clean Air Zone or Low Emission Zone is where targeted action is being taken to improve air quality and reduce the number of polluting vehicles and is usually defined over a certain area, such as a city centre.</p>
+                            <p>A Clean Air Zone or Low Emission Zone is where targeted action is being taken to improve air quality and reduce the number of polluting vehicles and is usually defined over a certain area, such as a city centre.</p>
+                            <p class="mb-0">To be awarded points in the Scorecards the zone must be more than one street.</p>
                             """,
                     },
                     {
@@ -1205,10 +1207,12 @@ class Methodology2023View(CheckForDownPageMixin, TemplateView):
                         "importance": "Medium",
                         "how_marked": "National Data and Volunteer Research",
                         "criteria": """
-                            <p class="mb-0"><i>Data is not currently available to create the criteria for this question. This will be published with the complete methodology when the Scorecard results are published.</i></p>
+                            <p>We will use the Active Travel England's capability ratings to answer this question. The following points will be awarded for each of the 5 different ratings used by Active Travel England.</p>
+                            <p class="mb-0">Points awarded if if the local authority received a "Rating 1". Further marks awarded if the local authority received a "Rating 2", "Rating 3", or "Rating 4" they will receive further points consecutively.</p>
                             """,
                         "clarifications": """
-                            <p class="mb-0">TBC</p>
+                            <p><a href="https://www.gov.uk/government/publications/local-authority-active-travel-capability-ratings/local-authority-active-travel-capability-ratings-accessible-version" class="d-inline">Active Travel England's capability ratings can be found here</a>.</p>
+                            <p class="mb-0">Where a Combined Authority has been marked for the region the Combined Authorities score will be applied to every local authority within the area.</p>
                             """,
                     },
                     {
@@ -1317,6 +1321,46 @@ class Methodology2023View(CheckForDownPageMixin, TemplateView):
                             <p>Approved = Passed a planning application in favour of expansion or construction of a road/airport since 2019.</p>
                             <p>Expanded = A road/airport has been expanded after 2019, even if it received planning approval before 2019. In the case of airports the expansion would include increasing passenger numbers.</p>
                             <p class="mb-0">Built = A road/airport has been built after 2019, even if it received planning approval before 2019.</p>
+                            """,
+                    },
+                    {
+                        "council_types": ["single", "district"],
+                        "england_only": "yes",
+                        "wales_apply": "yes",
+                        "code": "12a",
+                        "name": "Do the NO2 levels in a significant proportion of neighbourhoods within the council’s area exceed the safe World Health Organisation (WHO) air pollution guidelines?",
+                        "topic": "Air Quality - NO2",
+                        "importance": "High",
+                        "how_marked": "National Data",
+                        "criteria": """
+                            <p><strong>Negatively Scored Question</strong></p>
+                            <p>A council will be negatively scored if they have 25% or more LSOAs (Lower-layer Super Output Areas) above the World Health Organisations (WHO) NO2 guidelines.</p>
+                            <p class="mb-0">A council will be further negatively scored if they have 75% or more LSOAs (Lower-layer Super Output Areas) above the World Health Organisations (WHO) NO2 guidelines.</p>
+                            """,
+                        "clarifications": """
+                            <p>NO2 - Nitrogen dioxide, or NO2, is a gaseous air pollutant composed of nitrogen and oxygen and is one of a group of related gases called nitrogen oxides, or NOx. NO2 forms when fossil fuels such as coal, oil, gas or diesel are burned at high temperatures. NO2 in the UK is mostly a result of fossil fuel cars. Data for NO2 in the UK is strong due to a good network of national sensors therefore we have used a stronger criteria.</p>
+                            <p>LSOAs (Lower-layer Super Output Areas) are small areas designed to be of a similar population size, with an average of approximately 1,500 residents or 650 households. They are used to form the basis of the census.</p>
+                            <p class="mb-0"><strong>WHO NO2 guidelines:</strong> Nitrogen dioxide (NO2) concentrations of 10 µg/m3 annual average.</p>
+                            """,
+                    },
+                    {
+                        "council_types": ["single", "district"],
+                        "england_only": "yes",
+                        "wales_apply": "yes",
+                        "code": "12b",
+                        "name": "Do the PM 2.5 levels in a significant proportion of neighbourhoods in the council’s area exceed the safe World Health Organisation (WHO) air pollution guidelines?",
+                        "topic": "Air Quality - NO2",
+                        "importance": "Medium",
+                        "how_marked": "National Data",
+                        "criteria": """
+                            <p><strong>Negatively Scored Question</strong></p>
+                            <p>A local authority will be negatively scored if they have 25% or more LSOAs (Lower-layer Super Output Areas) above the World Health Organisations (WHO) PM 2.5 guidelines.</p>
+                            <p class="mb-0">A local authority will be further negatively scored if they have 75% or more LSOAs (Lower-layer Super Output Areas) above the World Health Organisations (WHO) PM 2.5 guidelines.</p>
+                            """,
+                        "clarifications": """
+                            <p>PM2.5 (Particulate Matter2.5) is the tiny particles or droplets in the air that are two and one half microns or less in width. PM 2.5 can be caused by burning fossil fuels, tyre wear and brake dust from cars and even weather variations. Data for PM 2.5 is less accurate at the local level and relies upon modelling due to a lack of national sensors.</p>
+                            <p>LSOAs (Lower-layer Super Output Areas) are small areas designed to be of a similar population size, with an average of approximately 1,500 residents or 650 households. They are used to form the basis of the census.</p>
+                            <p class="mb-0"><strong>WHO PM2.5 guidelines:</strong> PM 2.5 concentrations of 5 μg/m3 annual average."</p>
                             """,
                     },
                     {
@@ -1621,7 +1665,7 @@ class Methodology2023View(CheckForDownPageMixin, TemplateView):
                             <p>Points awarded if the council requires new homes to be operationally net zero with the policy implemented from 2030 to 2040.</p>
                             <p>More points awarded if the council requires new homes to be operationally net zero with the policy already implemented since 2019 or with implementation by 2030.</p>
                             <p>Any date to implement the policy after 2040 would not be awarded points.</p>
-                            <p class="mb-0">This would be equivalent for Scottish authorities to mandate the “Platinum” building standard for carbon emissions for all new buildings.</p>
+                            <p class="mb-0">This would be equivalent for Scottish authorities to mandate the 'Platinum' building standard for carbon emissions for all new buildings.</p>
                             """,
                         "clarifications": """
                             <p>For operationally net-zero policies, we will accept those that define this as only concerning regulated emissions. Definitions for operationally net-zero and regulated emissions are below.</p>
@@ -1763,11 +1807,14 @@ class Methodology2023View(CheckForDownPageMixin, TemplateView):
                         "name": "Has the Council approved a planning application for a carbon intensive energy system to be built or expanded from 2019?",
                         "topic": "Carbon Intensive Industry",
                         "importance": "High",
-                        "how_marked": "FOI",
+                        "how_marked": "National Data",
                         "criteria": """
-                            <p><strong>Negatively Scored Question:</strong></p>
+                            <p><strong>Negatively Scored Question</strong></p>
                             <p>Points deducted if the council has approved a carbon intensive energy system since 2019. A carbon energy intensive system includes coal mines, fracking/shale gas/gas drilling, oil drilling, and unabated fossil fuel generation.</p>
                             """,
+                        "clarifications": """
+                            <p class="mb-0">The data has been compiled using the <a href="https://drillordrop.com/planning/" class="d-inline">Drill or Drop database on approval of oil, gas and coal projects</a>.</p>
+                            """
                     },
                 ],
             },
@@ -2625,7 +2672,7 @@ class Methodology2023View(CheckForDownPageMixin, TemplateView):
                         "importance": "Low",
                         "how_marked": "National Data",
                         "criteria": """
-                            <p class="mb-0">Criteria met if a council has banned the use of pesticides in parks and road verges where they have control. This ban must include the street cleaning/weed control team.</p>
+                            <p class="mb-0">Criteria met if a council has banned the use of glyphosphate or all pesticides in parks and road verges where they have control. This ban must include the street cleaning/weed control team.</p>
                             """,
                         "clarifications": """
                             <p>Banning pesticides includes banning glyphosate and any other pesticides that the council have been using.</p>


### PR DESCRIPTION
Applies the latest version of the Climate Action Scorecards methodology to the "upcoming" Methodology page on the Climate Plan Scorecards site.

Fixes #541.