### PR TITLE
[scorecards] fix section page evidence link display

### DIFF
--- a/scoring/templates/scoring/includes/question-content-table-cell.html
+++ b/scoring/templates/scoring/includes/question-content-table-cell.html
@@ -32,6 +32,7 @@
                     <dd class="col-sm-8">{{ how_marked }}</dd>
                     <dt class="col-sm-4">Question weight</dt>
                     <dd class="col-sm-8">{{ weighting }}</dd>
+                    {% if evidence_links != 'CouncilTypeOnly' %}
                     <dt class="col-sm-4">Evidence</dt>
                     <dd class="col-sm-8">
                       {% for link in evidence_links %}
@@ -40,6 +41,7 @@
                         No evidence available.
                       {% endfor %}
                     </dd>
+                    {% endif %}
                 </dl>
             </div>
 

--- a/scoring/views.py
+++ b/scoring/views.py
@@ -524,6 +524,8 @@ class SectionView(CheckForDownPageMixin, SearchAutocompleteMixin, DetailView):
                 plan_sections=PlanSection.objects.filter(code=section.code),
             )
 
+            first_comparison = comparison_slugs[0]
+
             comparison_scores = comparison_sections[section.code]
 
             for score in comparison_scores:
@@ -538,8 +540,17 @@ class SectionView(CheckForDownPageMixin, SearchAutocompleteMixin, DetailView):
                         if answer.score < 0:
                             score["negative_points"] += answer.score
                             score["non_negative_max"] -= answer.score
+
+                        # need to add this manually to the section question object so it displays
+                        # the evidence if it's relevant
+                        if score["council_slug"] == first_comparison:
+                            comparison_questions[code][
+                                "evidence_links"
+                            ] = answer.evidence_links.splitlines()
+
                     else:
                         comparison_questions[code]["comparisons"].append({"score": "-"})
+                        comparison_questions[code]["evidence_links"] = []
 
                 if score["negative_points"] < 0:
                     score["negative_percent"] = (
@@ -592,6 +603,7 @@ class SectionView(CheckForDownPageMixin, SearchAutocompleteMixin, DetailView):
             for question in questions:
                 comparison_questions[question.code] = {
                     "details": question,
+                    "evidence_links": "CouncilTypeOnly",
                     "comparisons": [],
                 }
 


### PR DESCRIPTION
Only display evidence bit if we've selected a council in some way as otherwise it doesn't make sense to display the evidence section.

Fixes #595