### PR TITLE
[Scorecards] Fixed council title property

### DIFF
--- a/scoring/views.py
+++ b/scoring/views.py
@@ -395,7 +395,7 @@ class CouncilView(CheckForDownPageMixin, SearchAutocompleteMixin, DetailView):
         context["sections"] = sorted(
             sections.values(), key=lambda section: section["code"]
         )
-        context["page_title"] = "{name} Climate Plan Scorecards".format(
+        context["page_title"] = "{name} Climate Action Scorecard".format(
             name=council.name
         )
 


### PR DESCRIPTION
Fixes: https://github.com/mysociety/caps/issues/623

Title element and property="og:title" were still using "plan" for the Climate Action Scorecards. Both elements have been updated to replace "Climate Plan Scorecards" with "Climate Action Scorecard"