### PR TITLE
Small fixes to plan updates and displays

### DIFF
--- a/caps/management/commands/import_plans.py
+++ b/caps/management/commands/import_plans.py
@@ -1,9 +1,14 @@
-from os.path import join
-from datetime import date
 import math
+from datetime import date
+from os.path import join
 
-import pandas as pd
 import numpy as np
+import pandas as pd
+from django.conf import settings
+from django.core.files import File
+from django.core.management.base import BaseCommand, CommandError
+from django.db.models import Count, Q
+from django.template.defaultfilters import pluralize
 
 from caps.models import Council, PlanDocument
 from caps.utils import (
@@ -12,13 +17,6 @@ from caps.utils import (
     date_from_text,
     integer_from_text,
 )
-
-from django.core.management.base import BaseCommand, CommandError
-from django.core.files import File
-from django.template.defaultfilters import pluralize
-from django.db.models import Count, Q
-
-from django.conf import settings
 
 
 class Command(BaseCommand):

--- a/caps/management/commands/import_plans.py
+++ b/caps/management/commands/import_plans.py
@@ -133,9 +133,17 @@ class Command(BaseCommand):
         plans_to_delete_count = 0
         for council_code in plans_to_import.keys():
             council = Council.objects.get(gss_code=council_code)
-            plans = PlanDocument.objects.filter(
-                council=council,
-            ).exclude(url__in=plans_to_import[council_code])
+            plans = (
+                PlanDocument.objects.filter(
+                    council=council,
+                )
+                .exclude(
+                    url__in=plans_to_import[council_code],
+                )
+                .exclude(
+                    document_type=PlanDocument.CITIZENS_ASSEMBLY,
+                )
+            )
             for plan in plans:
                 plans_to_delete_count += 1
                 council_plans = plans_to_delete.get(council_code, set())

--- a/caps/management/commands/import_plans.py
+++ b/caps/management/commands/import_plans.py
@@ -113,15 +113,20 @@ class Command(BaseCommand):
                 else:
                     plan = PlanDocument.objects.get(council=council, url=row["url"])
                     diffs = 0
+                    diff_keys = []
                     for key, value in self.get_plan_defaults_from_row(row).items():
                         if getattr(plan, key) != value:
                             diffs = 1
+                            diff_keys.append(key)
 
                     if diffs != 0:
                         self.plans_to_process[index] = "update"
                         plan_update_count += 1
                         self.print_change(
-                            "updating plan for %s", row["council"], verbosity=2
+                            "updating plan for %s (%s changed)",
+                            row["council"],
+                            ", ".join(diff_keys),
+                            verbosity=2,
                         )
 
         plans_to_delete = {}
@@ -135,7 +140,13 @@ class Command(BaseCommand):
                 plans_to_delete_count += 1
                 council_plans = plans_to_delete.get(council_code, set())
                 council_plans.update([plan.url])
-                self.print_change("deleting plan for %s", council.name, verbosity=2)
+                self.print_change(
+                    "deleting plan for %s - %s (%s)",
+                    council.name,
+                    plan.title,
+                    plan.document_type,
+                    verbosity=2,
+                )
                 plans_to_delete[council_code] = council_plans
 
         # if a council isn't in the sheet we should remove it entirely from the database

--- a/caps/templates/caps/includes/document-list.html
+++ b/caps/templates/caps/includes/document-list.html
@@ -2,12 +2,12 @@
         <div class="council-documents">
             {% for group, group_docs in documents.items %}
                 {% for plandocument in group_docs %}
-                    {% if forloop.counter == 2 %}
+                    {% if document_count > 3 and forloop.counter == 2 %}
                         <details class="details">
                             <summary>Show more {{ group }} documents</summary>
-                        {% endif %}
-                        {% include 'caps/includes/council-document.html' with plandocument=plandocument council=council %}
-                        {% if forloop.counter > 1 and forloop.last %}</details>{% endif %}
+                    {% endif %}
+                    {% include 'caps/includes/council-document.html' with plandocument=plandocument council=council %}
+                    {% if document_count > 3 and forloop.counter > 1 and forloop.last %}</details>{% endif %}
                 {% endfor %}
             {% empty %}
                 <p class="text-muted mb-3">We couldn’t find any climate action plans for this council.</p>

--- a/caps/tests/test_import.py
+++ b/caps/tests/test_import.py
@@ -153,14 +153,14 @@ class ImportPlansTestCase(ImportTestCase):
             out = self.call_command(confirm_changes=1, verbosity=2)
             self.assertEquals(
                 out,
-                "updating plan for Borsetshire\nadding new plan for West Borsetshire\n1 plan will be added\n1 plan will be updated\nCouncils with a plan went from 2 to 3\nNumber of documents went from 2 to 3\nNumber of plans went from 2 to 3\n",
+                "updating plan for Borsetshire (date_last_found changed)\nadding new plan for West Borsetshire\n1 plan will be added\n1 plan will be updated\nCouncils with a plan went from 2 to 3\nNumber of documents went from 2 to 3\nNumber of plans went from 2 to 3\n",
             )
 
         with self.settings(PROCESSED_CSV="caps/tests/test_processed_update_url.csv"):
             out = self.call_command(confirm_changes=1, verbosity=2)
             self.assertEquals(
                 out,
-                "adding new plan for Borsetshire\ndeleting plan for Borsetshire\n1 plan will be added\n1 plan will be deleted\nCouncils with a plan is unchanged at 3\nNumber of documents is unchanged at 3\nNumber of plans is unchanged at 3\n",
+                "adding new plan for Borsetshire\ndeleting plan for Borsetshire -  (1)\n1 plan will be added\n1 plan will be deleted\nCouncils with a plan is unchanged at 3\nNumber of documents is unchanged at 3\nNumber of plans is unchanged at 3\n",
             )
 
     def test_update_properties(self):

--- a/caps/views.py
+++ b/caps/views.py
@@ -273,7 +273,10 @@ class CouncilDetailView(DetailView):
         Get information on the documents associated with this council
         """
         context = {}
-        documents = council.plandocument_set.order_by("-created_at").all()
+        documents = council.plandocument_set.order_by(
+            "-created_at", "-updated_at"
+        ).all()
+        context["document_count"] = documents.count()
         grouped_documents = defaultdict(list)
         for document in documents:
             grouped_documents[document.get_document_type].append(document)

--- a/caps/views.py
+++ b/caps/views.py
@@ -273,7 +273,7 @@ class CouncilDetailView(DetailView):
         Get information on the documents associated with this council
         """
         context = {}
-        documents = council.plandocument_set.order_by("-updated_at").all()
+        documents = council.plandocument_set.order_by("-created_at").all()
         grouped_documents = defaultdict(list)
         for document in documents:
             grouped_documents[document.get_document_type].append(document)


### PR DESCRIPTION
This changes the order of document display on the council page to use the created versus updated date on the assumption that more recently added documents are more relevant, as oppose to documents that might have had a small detailed updated.

It also updates the import to ignore citizens assembly reports when deleted documents not in the plans spreadsheet, plus some small improvements to the diagnostic messages to make it easier to see what's happening.

Fixes #619 
Fixes #634
