### PR TITLE
[Scorecards] Added timeline image to methodology 2025

### DIFF
--- a/scoring/templates/scoring/methodology/2025/_details.html
+++ b/scoring/templates/scoring/methodology/2025/_details.html
@@ -1,3 +1,4 @@
+                    {% load static %}
 
                     <h3 class="mt-5 mb-3">Date range of evidence</h3>
 
@@ -663,6 +664,9 @@
                     </p>
 
                     <h2 id="section-scoring-process" class="mt-5 mt-lg-6 mt-xl-7 mb-3">Scoring Process</h2>
+
+                    <img alt="Timeline showing: January to April 2024, Methodology review and sector consultations; May 2024, Publish updated metrics for 2025 Scorecards; August to October 2024, First marking with volunteers; November to December 2024, Five week Right of Reply period; January to March 2025, Scoring audit; Summer 2025, scorecards launch" class="d-block my-3 py-2 py-lg-3 px-lg-3 border rounded" height="150" src="{% static 'scoring/img/2025-timeline-02.png' %}" style="max-width: 100%; height: auto;" width="700">
+
                     <h3 class="mt-4">First Mark</h3>
                     <p>A team of volunteers mark all questions for all councils that are marked by volunteer research as shown in the methodology according to the question criteria. About two thirds of all of the Scorecard questions are marked by volunteer research. </p>
 

--- a/scoring/templates/scoring/methodology/2025/_intro.html
+++ b/scoring/templates/scoring/methodology/2025/_intro.html
@@ -1,3 +1,4 @@
+                    {% load static %}
                     <div class="alert alert-primary2025 mb-5 p-4 border-yellow" role="alert">
                       <p>Looking for information about how we scored previous rounds of the Scorecards?</p>
                       <div class="d-flex flex-wrap gap-3">
@@ -30,7 +31,9 @@
                     <p>The one question that has been removed was Question 1a "Has the council reduced single use plastic in its buildings and events?" in Waste Reduction &amp; Food, due to changes in UK law making it a legal requirement to ban the use and sale of some single use plastic.</p>
                     
                     <p>We created this updated criteria through extensive research and consultation with council staff, councillors, campaigners and other organisations. To understand what action we will be scoring and the question weightings, please read the complete draft methodology below.</p>
-                    
+
+                    <img alt="Timeline showing: January to April 2024, Methodology review and sector consultations; May 2024, Publish updated metrics for 2025 Scorecards; August to October 2024, First marking with volunteers; November to December 2024, Five week Right of Reply period; January to March 2025, Scoring audit; Summer 2025, scorecards launch" class="d-block mx-auto my-4 my-lg-5" height="150" src="{% static 'scoring/img/2025-timeline-02.png' %}" style="max-width: 100%; height: auto;" width="700">
+
                     <p><strong>Whilst every effort has been made to make this methodology complete, Climate Emergency UK reserves the right to make changes to the methodology where deemed appropriate between now and Summer 2025.</strong> Changes may be made, for example, if national policy changes between now and Summer 2025 and this impacts our questions; or if the data needed to answer a particular question is no longer available to use. An updated methodology, if there are any changes, identical to the one used in the marking, will be published, alongside the Council Climate Action Scorecards in Summer 2025.</p>
                     
                     <p>The Council Climate Action Scorecards is a project of Climate Emergency UK, in partnership with mySociety.</p>


### PR DESCRIPTION
Added timeline to Methodology 2025

### Summary
<img width="1918" alt="Screenshot 2024-07-25 at 11 28 42" src="https://github.com/user-attachments/assets/2cb23824-d043-4462-99c9-7c855b693320">


### Scoring Process

<img width="1918" alt="Screenshot 2024-07-25 at 11 34 54" src="https://github.com/user-attachments/assets/ada22ae3-2b00-416e-8653-3ade065ab8f9">

<img width="1918" alt="Screenshot 2024-07-25 at 11 34 29" src="https://github.com/user-attachments/assets/114586fd-0404-4175-a421-c33c8e0eefd1">

I added a box in the scoring process. I thought without it looked a bit odd, without it, like if all milestone text was just floating around. Let me know which colour you prefer.

<img width="1918" alt="Screenshot 2024-07-25 at 11 29 43" src="https://github.com/user-attachments/assets/42640aff-f4e4-49a4-af82-a054fa3366a8">
<img width="1918" alt="Screenshot 2024-07-25 at 11 29 57" src="https://github.com/user-attachments/assets/7041b5e5-883a-456e-8ac3-38bf4f09776b">
