### PR TITLE
Avoid displaying ".0" decimals on question marks

### DIFF
--- a/caps/templatetags/caps_templatetags.py
+++ b/caps/templatetags/caps_templatetags.py
@@ -71,6 +71,22 @@ def percentage(value: float):
     return f"{value * 100:.0f}%"
 
 
+@register.filter
+def format_mark(value):
+    """
+    Display whole-number marks as a whole numbers, and
+    fractional marks as decimals, removing trailing zeroes.
+    """
+    try:
+        value = float(value)
+        if value.is_integer():
+            return f"{int(value)}"
+        else:
+            return f"{value}"
+    except (ValueError, TypeError):
+        return value
+
+
 @register.simple_tag(takes_context=True)
 def council_card(context: dict, slug: str, title="", color: str = "red"):
     """

--- a/scoring/templates/scoring/council.html
+++ b/scoring/templates/scoring/council.html
@@ -296,12 +296,12 @@
                 </td>
 
                 <td data-column="score" class="score border-bottom">
-                    <span>{{ answer.score }}/{{ answer.max }}</span>
+                    <span>{{ answer.score|format_mark }}/{{ answer.max }}</span>
                 </td>
 
               {% for comparison in answer.comparisons %}
                 <td data-column="score" class="d-none d-md-table-cell score border-bottom">
-                    <span>{{ comparison.score }}/{{ comparison.max }}</span>
+                    <span>{{ comparison.score|format_mark }}/{{ comparison.max }}</span>
                 </td>
               {% endfor %}
 

--- a/scoring/templates/scoring/section.html
+++ b/scoring/templates/scoring/section.html
@@ -320,7 +320,7 @@
 
               {% for comparison in question.comparisons %}
                 <td data-column="score" class="text-start text-md-end d-none flex-row d-md-table-cell score">
-                    <span class="me-2">{{ comparison.score }}/{{ question.details.max_score }}</span>
+                    <span class="me-2">{{ comparison.score|format_mark }}/{{ question.details.max_score }}</span>
                     <span class="badge bg-secondary d-md-none">{{ comparison.council_name }}</span>
                 </td>
               {% endfor %}


### PR DESCRIPTION
Fixes #699. The question, as outlined there, is:

> Can the number of marks a council got on a question ever be a fraction with more than one decimal place? And if it can, do we care if it gets rounded to one decimal place?

If the answer to either of those questions is "no" then we should be good to merge this PR.