### PR TITLE
Split single tier types

### DIFF
--- a/caps/models.py
+++ b/caps/models.py
@@ -480,20 +480,10 @@ class Council(models.Model):
         return df
 
     def get_scoring_group(self):
-        if self.country == self.NORTHERN_IRELAND:
-            group = "northern-ireland"
-        elif self.authority_type in ("CC", "LBO", "MD", "UA"):
-            group = "single"
-        elif self.authority_type == "NMD":
-            group = "district"
-        elif self.authority_type == "CTY":
-            group = "county"
-        elif self.authority_type in ["COMB", "SRA"]:
-            group = "combined"
-        else:
-            group = "single"
-
-        return self.SCORING_GROUPS[group]
+        for slug, group in self.SCORING_GROUPS.items():
+            if self.authority_type in group["types"]:
+                return group
+        return self.SCORING_GROUPS["single"]
 
     @property
     def powers(self):

--- a/caps/models.py
+++ b/caps/models.py
@@ -632,6 +632,19 @@ class Council(models.Model):
         return descriptions_to_codes.get(authority_type.lower().strip())
 
     @classmethod
+    def authority_type_desc(cls, authority_type_code):
+        """
+        Return an authority type description given a code, or None if the code
+        isn't in the authority type choices
+        """
+        if pd.isnull(authority_type_code):
+            return None
+        codes_to_descriptions = dict(
+            (code, type) for code, type in Council.AUTHORITY_TYPE_CHOICES
+        )
+        return codes_to_descriptions.get(authority_type_code)
+
+    @classmethod
     def percent_with_plan(cls):
         """
         Return the percentage of councils that have a plan document
@@ -675,6 +688,14 @@ class Council(models.Model):
             ("Regions of England", (regions)),
             ("English Counties", (counties)),
         )
+
+    @classmethod
+    def get_authority_type_choices_for_scoring_group(cls, scoring_group_slug):
+        return [
+            choice
+            for choice in cls.AUTHORITY_TYPE_CHOICES
+            if choice[0] in cls.SCORING_GROUPS["single"]["types"]
+        ]
 
 
 class OverwriteStorage(FileSystemStorage):

--- a/caps/templates/caps/council_cards/scorecard.html
+++ b/caps/templates/caps/council_cards/scorecard.html
@@ -49,23 +49,14 @@
                     {{ council.name }} was a <strong>top performer</strong>
                     {% if scoring_accolades.overall %}
                         amongst
-
-                        {% include 'caps/includes/authority_type.html' with group=scoring_group %}
-
-                        councils.
+                        {% include 'scoring/includes/scoring-group-name.html' with group=scoring_group.slug plural=True %}.
                     {% elif scoring_accolades.num_sections == 1 %}
                         amongst
-
-                        {% include 'caps/includes/authority_type.html' with group=scoring_group %}
-
-                        councils,
+                        {% include 'scoring/includes/scoring-group-name.html' with group=scoring_group.slug plural=True %},
                         in the <strong>{{ scoring_accolades.example_section }}</strong> section.
                     {% else %}
                         amongst
-
-                        {% include 'caps/includes/authority_type.html' with group=scoring_group %}
-
-                        councils,
+                        {% include 'scoring/includes/scoring-group-name.html' with group=scoring_group.slug plural=True %},
                         in {{ scoring_accolades.num_sections|apnumber }} sections
                         including <strong>{{ scoring_accolades.example_section }}</strong>.
                     {% endif %}
@@ -89,10 +80,7 @@
                     </th>
                     <th class="border-0" scope="col">
                         Average
-
-                        {% include 'caps/includes/authority_type.html' with group=scoring_group %}
-
-                        council
+                        {% include 'scoring/includes/scoring-group-name.html' with group=scoring_group.slug plural=False %}
                     </th>
                 </tr>
             </thead>

--- a/caps/templates/caps/includes/authority_type.html
+++ b/caps/templates/caps/includes/authority_type.html
@@ -1,1 +1,0 @@
-{% if group.slug == 'northern-ireland' %}{{ group.name }}{% else %}{{ group.name|lower }}{% endif %}

--- a/scoring/filters.py
+++ b/scoring/filters.py
@@ -35,6 +35,11 @@ class PlanScoreFilter(django_filters.FilterSet):
         choices=Council.get_county_choices(),
     )
 
+    authority_type = django_filters.ChoiceFilter(
+        field_name="council__authority_type",
+        choices=Council.get_authority_type_choices_for_scoring_group("single"),
+    )
+
     class Meta:
         model = PlanScore
         fields = []

--- a/scoring/mixins.py
+++ b/scoring/mixins.py
@@ -26,24 +26,18 @@ class AdvancedFilterMixin:
                 params.get("population", None) is not None
                 and params["population"] != ""
             ):
-                descs.append(params.get("population", None) is not None)
+                descs.append(params.get("population", None))
             if params.get("control", None) is not None and params["control"] != "":
-                descs.append(params.get("control", None) is not None)
+                descs.append(params.get("control", None))
             if (
                 params.get("ruc_cluster", None) is not None
                 and params["ruc_cluster"] != ""
             ):
                 descs.append(
-                    PlanScore.ruc_cluster_description(
-                        params.get("ruc_cluster", None) is not None
-                    )
+                    PlanScore.ruc_cluster_description(params.get("ruc_cluster", None))
                 )
             if params.get("imdq", None) is not None and params["imdq"] != "":
-                descs.append(
-                    "deprivation quintile {}".format(
-                        params.get("imdq", None) is not None
-                    )
-                )
+                descs.append("deprivation quintile {}".format(params.get("imdq", None)))
             if params.get("country", None) is not None and params["country"] != "":
                 descs.append(Council.country_description(params["country"]))
             if (

--- a/scoring/mixins.py
+++ b/scoring/mixins.py
@@ -1,8 +1,8 @@
-from caps.models import Council
 from django.conf import settings
 from django.contrib.auth.mixins import AccessMixin
 from django.shortcuts import redirect
 
+from caps.models import Council
 from scoring.models import PlanScore
 
 
@@ -46,6 +46,11 @@ class AdvancedFilterMixin:
                 )
             if params.get("country", None) is not None and params["country"] != "":
                 descs.append(Council.country_description(params["country"]))
+            if (
+                params.get("authority_type", None) is not None
+                and params["authority_type"] != ""
+            ):
+                descs.append(Council.authority_type_desc(params["authority_type"]))
             if params.get("region", None) is not None and params["region"] != "":
                 descs.append(params["region"])
             if params.get("county", None) is not None and params["county"] != "":
@@ -59,6 +64,9 @@ class AdvancedFilterMixin:
             authority_type["slug"]
         )
         context["county_filter"] = Council.get_county_choices()
+        context["authority_type_filter"] = (
+            Council.get_authority_type_choices_for_scoring_group("single")
+        )
 
         return context
 

--- a/scoring/mixins.py
+++ b/scoring/mixins.py
@@ -18,7 +18,7 @@ class PrivateScorecardsAccessMixin(AccessMixin):
 
 
 class AdvancedFilterMixin:
-    def setup_filter_context(self, context, filter, authority_type):
+    def setup_filter_context(self, context, filter, scoring_group):
         if getattr(filter.form, "cleaned_data", None) is not None:
             params = filter.form.cleaned_data
             descs = []
@@ -61,7 +61,7 @@ class AdvancedFilterMixin:
 
         context["urbanisation_filter"] = PlanScore.RUC_TYPES
         context["population_filter"] = PlanScore.POPULATION_FILTER_CHOICES.get(
-            authority_type["slug"]
+            scoring_group["slug"]
         )
         context["county_filter"] = Council.get_county_choices()
         context["authority_type_filter"] = (

--- a/scoring/templates/scoring/council-preview.html
+++ b/scoring/templates/scoring/council-preview.html
@@ -12,7 +12,7 @@
     {% if plan_score.top_performer %}
     <span class="mb-5 me-auto fw-bold subtitle text-shadow text-yellow-300 mt-2">
         {% include 'caps/icons/scorecards-star.html' with classes='me-1 align-text-top' width='1.2em' height='auto' role='presentation' %}
-        High scoring council &mdash; {% include 'caps/includes/authority_type.html' with group=authority_type %}
+        High scoring {% include 'scoring/includes/scoring-group-name.html' with group=scoring_group.slug plural=False %}
     </span>
     {% endif %}
 

--- a/scoring/templates/scoring/council-top-performer-overall-preview.html
+++ b/scoring/templates/scoring/council-top-performer-overall-preview.html
@@ -6,7 +6,7 @@
 {% block content %}
     <div class="mb-5 me-auto fw-bold text-shadow text-yellow-300 d-flex align-items-center" style="font-size: 3rem; line-height: 1.2;">
         {% include 'caps/icons/scorecards-star.html' with classes='me-4 align-text-top' width='1.2em' height='auto' role='presentation' %}
-        <span>High scorer &mdash; {% include 'caps/includes/authority_type.html' with group=authority_type %} councils</span>
+        <span>High scorer &mdash; {% include 'scoring/includes/scoring-group-name.html' with group=scoring_group.slug plural=True %}</span>
     </div>
     <div class="open-graph-preview__grid">
         <div class="grid__name">

--- a/scoring/templates/scoring/council.html
+++ b/scoring/templates/scoring/council.html
@@ -24,7 +24,7 @@
         {% if plan_score.top_performer %}
         <div class="d-flex align-items-center">
             {% include 'caps/icons/scorecards-star.html' with classes='me-2' width='1rem' height='1rem' role='presentation' %}
-            This council is one of the highest scoring {% include 'caps/includes/authority_type.html' with group=authority_type %} councils.
+            This council is one of the highest scoring {% include 'scoring/includes/scoring-group-name.html' with group=council.get_scoring_group.slug plural=True %}.
         </div>
         {% endif %}
         <dl class="mt-4 mb-0 council-stats-grid">
@@ -306,15 +306,15 @@
               {% endfor %}
 
                 <td class="d-none d-md-table-cell top-tier-score border-bottom border-end">
-                  <a href="{% url 'scoring:question' answer.code %}?type={{ authority_type.slug }}" class="mx-auto" style="text-transform: none">
+                  <a href="{% url 'scoring:question' answer.code %}?type={{ council.get_scoring_group.slug }}" class="mx-auto" style="text-transform: none">
                         {{ answer.council_count }} out of {{ council_count }}
                     </a>
                     <span class="fs-8 mt-1 me-0 ms-auto d-block">
-                        {% include 'caps/includes/authority_type.html' with group=authority_type %}
+                        {% include 'scoring/includes/scoring-group-name.html' with group=council.get_scoring_group.slug plural=True %}
                       {% if answer.type == "negative" %}
-                        councils got <strong>no penalty marks</strong> for this question.
+                        got <strong>no penalty marks</strong> for this question.
                       {% else %}
-                        councils got full marks for this question.
+                        got full marks for this question.
                       {% endif %}
                     </span>
                 </td>

--- a/scoring/templates/scoring/home.html
+++ b/scoring/templates/scoring/home.html
@@ -58,7 +58,7 @@
             <div class="table-header mb-4 d-md-flex align-items-end">
                 <div class="me-md-auto">
                     <h3 class="d-inline-block">
-                        <span>{{ authority_type_label }}</span>
+                        <span>{{ scoring_group.name }}</span>
                         {% if filter_descs %}
                         <span>·</span>
                         {% if filter_descs|length > 1 %}
@@ -133,7 +133,7 @@
                         </tr>
                         <tr class="second-row position-sticky z-index-4">
                             <th scope="col" style="min-width:250px" class="bg-primary-100 position-sticky z-index-4">
-                                <span class="ms-4 fs-6 fw-bold d-block">{{ authority_type_label }} average</span>
+                                <span class="ms-4 fs-6 fw-bold d-block">{{ scoring_group.name }} average</span>
                             </th>
                             <th scope="col" class="bg-primary-100 total-score position-sticky z-index-4 bg-green-l2">              
                                 {% include 'scoring/includes/score-bar.html' with percentage=averages.total.percentage average=1 %}
@@ -235,7 +235,7 @@
                             </th>
                         <tr class="second-row position-sticky z-index-4">
                             <th class="bg-white" scope="col" style="min-width:250px">
-                                <span class="ms-4 fs-6 fw-bold d-block" style="white-space: break-spaces;">{{ authority_type_label }} average</span>
+                                <span class="ms-4 fs-6 fw-bold d-block" style="white-space: break-spaces;">{{ scoring_group.name }} average</span>
                             </th>
                             <th scope="col" class="total-score position-sticky z-index-4">              
                                 {% include 'scoring/includes/score-bar.html' with percentage=averages.total.percentage average=1 %}

--- a/scoring/templates/scoring/home_combined.html
+++ b/scoring/templates/scoring/home_combined.html
@@ -49,7 +49,7 @@
                         </tr>
                         <tr class="second-row position-sticky z-index-4">
                             <th scope="col" style="min-width:250px" class="bg-primary-100 position-sticky z-index-4">
-                                <span class="ms-4 fs-6 fw-bold d-block">{{ authority_type_label }} average</span>
+                                <span class="ms-4 fs-6 fw-bold d-block">{{ scoring_group.name }} average</span>
                             </th>
                             <th scope="col" class="bg-primary-100 total-score position-sticky z-index-4 bg-green-l2">              
                                 {% include 'scoring/includes/score-bar.html' with percentage=averages.total.percentage average=1 %}
@@ -139,7 +139,7 @@
                             </th>
                         <tr class="second-row position-sticky z-index-4">
                             <th class="bg-white" scope="col" style="min-width:250px">
-                                <span class="ms-4 fs-6 fw-bold d-block" style="white-space: break-spaces;">{{ authority_type_label }} average</span>
+                                <span class="ms-4 fs-6 fw-bold d-block" style="white-space: break-spaces;">{{ scoring_group.name }} average</span>
                             </th>
                             <th scope="col" class="total-score position-sticky z-index-4">              
                                 {% include 'scoring/includes/score-bar.html' with percentage=averages.total.percentage average=1 %}

--- a/scoring/templates/scoring/includes/advanced-filter.html
+++ b/scoring/templates/scoring/includes/advanced-filter.html
@@ -150,6 +150,38 @@
                         </div>
                         {% endif %}
 
+                        {% if authority_type == 'single' %}
+                        <div id="accordionAuthorityType" class="accordion-item">
+                          <h2 class="accordion-header" id="headingEight">
+                            <button class="accordion-button flex-row justify-content-between fs-7 fs-lg-6 collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseEight" aria-expanded="false" aria-controls="collapseEight">
+                              Single Tier authority type
+                              <span id="authorityTypeActiveFilter" class="fs-9 text-uppercase badge bg-secondary filter-badge ms-2 me-3">Any</span>
+                            </button>
+                          </h2>
+                          <div id="collapseEight" class="accordion-collapse collapse" aria-labelledby="headingEight" data-bs-parent="#accordionAdvancedFilter">
+                            <div class="accordion-body">
+                                <fieldset class="criteria-group-wrapper">
+                                    <legend class="visually-hidden">
+                                        <button type="button">Single Tier authority type</button>
+                                    </legend>
+                                    <div class="option-group open-div">
+                                        <div class="form-check-flex py-2">
+                                            <input type="radio" class="form-check-input" id="authority_type_all" name="authority_type" value=""{% if filter_params.authority_type == "" or filter_params.authority_type is None %} checked{% endif %}>
+                                            <label class="form-check-label" for="authority_type_all">All</label>
+                                        </div>
+                                      {% for option in authority_type_filter %}
+                                        <div class="form-check-flex py-2">
+                                            <input type="radio" class="form-check-input" id="{{ option.0|slugify }}" name="authority_type" value="{{ option.0 }}"{% if filter_params.authority_type == option.0 %} checked{% endif %}>
+                                            <label class="form-check-label" for="{{ option.0|slugify }}">{{ option.1 }}</label>
+                                        </div>
+                                      {% endfor %}
+                                    </div>
+                                </fieldset>
+                            </div>
+                          </div>
+                        </div>
+                        {% endif %}
+
                         <div class="accordion-item">
                             <h2 class="accordion-header" id="headingFour">
                               <button class="accordion-button flex-row justify-content-between fs-7 fs-lg-6 collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseFour" aria-expanded="false" aria-controls="collapseFour">
@@ -391,6 +423,26 @@
           var elem = countyRadioButtons[i];
           elem.addEventListener('change',function(e){
               countyActiveLabel.textContent = this.nextElementSibling.textContent;
+          }
+          ,false);
+      }
+    }
+
+    // DISTRICT TYPE (Authority type)
+    var accordionAuthorityType= document.getElementById('accordionAuthorityType');
+    if(accordionAuthorityType) {
+      var authorityTypeRadioButtons = document.getElementsByName('authority_type');
+      var authorityTypeActiveLabel = document.getElementById('authorityTypeActiveFilter');
+
+      // Update active label on load
+      authorityTypeActiveLabel.textContent =  document.querySelector("#advancedFilterForm input[name=authority_type]:checked").nextElementSibling.textContent;
+
+      // Update active label on change
+      for(var i=0;i< authorityTypeRadioButtons.length;i++)
+      {
+          var elem = authorityTypeRadioButtons[i];
+          elem.addEventListener('change',function(e){
+              authorityTypeActiveLabel.textContent = this.nextElementSibling.textContent;
           }
           ,false);
       }

--- a/scoring/templates/scoring/includes/advanced-filter.html
+++ b/scoring/templates/scoring/includes/advanced-filter.html
@@ -13,11 +13,11 @@
         <div class="modal-body">
                 <div class="d-flex flex-column flex-wrap">
                     {% if filter_auth_type %}
-                    <input type="hidden" name="council_type" value="{{ authority_type }}">
+                    <input type="hidden" name="council_type" value="{{ scoring_group.slug }}">
                     {% endif %}
 
                     <div class="accordion" id="accordionAdvancedFilter">
-                        {% if authority_type == 'single' %}
+                        {% if scoring_group.slug == 'single' %}
                         <div id="accordionNation" class="accordion-item">
                           <h2 class="accordion-header" id="headingOne">
                             <button class="accordion-button flex-row justify-content-between fs-7 fs-lg-6" type="button" data-bs-toggle="collapse" data-bs-target="#collapseOne" aria-expanded="true" aria-controls="collapseOne">
@@ -117,7 +117,7 @@
                         </div>
                         {% endif %}
 
-                        {% if authority_type == 'district' %}
+                        {% if scoring_group.slug == 'district' %}
                         <div id="accordionCounty" class="accordion-item">
                           <h2 class="accordion-header" id="headingThree">
                             <button class="accordion-button flex-row justify-content-between fs-7 fs-lg-6 collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseThree" aria-expanded="false" aria-controls="collapseThree">
@@ -150,7 +150,7 @@
                         </div>
                         {% endif %}
 
-                        {% if authority_type == 'single' %}
+                        {% if scoring_group.slug == 'single' %}
                         <div id="accordionAuthorityType" class="accordion-item">
                           <h2 class="accordion-header" id="headingEight">
                             <button class="accordion-button flex-row justify-content-between fs-7 fs-lg-6 collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseEight" aria-expanded="false" aria-controls="collapseEight">
@@ -212,7 +212,7 @@
                             </div>
                           </div>
 
-                          {% if authority_type != 'combined' and authority_type != 'northern-ireland' %}
+                          {% if scoring_group.slug != 'combined' and scoring_group.slug != 'northern-ireland' %}
                           <div class="accordion-item">
                             <h2 class="accordion-header" id="headingFive">
                               <button class="accordion-button flex-row justify-content-between fs-7 fs-lg-6 collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseFive" aria-expanded="false" aria-controls="collapseFive">

--- a/scoring/templates/scoring/includes/main-filter.html
+++ b/scoring/templates/scoring/includes/main-filter.html
@@ -2,10 +2,10 @@
     <input class="form-control searchbar js-location-jump-autocomplete" type="search" placeholder="Council name" aria-label="Council name">
     <!-- <button class="btn btn-outline-success my-2 my-sm-0" type="submit">Search</button> -->
     <div class="type-council-option-wrapper mt-4" id="council-type-filter">
-        <a class="mb-1 btn btn-sm btn-outline-primary {% if authority_type == 'single' %} active{% endif %}" href="{% include 'scoring/includes/scoring_url.html' with slug='single' %}">Single Tier</a>
-        <a class="mb-1 btn btn-sm btn-outline-primary {% if authority_type == 'district' %} active{% endif %}" href="{% include 'scoring/includes/scoring_url.html' with slug='district' %}">District</a>
-        <a class="mb-1 btn btn-sm btn-outline-primary {% if authority_type == 'county' %} active{% endif %}" href="{% include 'scoring/includes/scoring_url.html' with slug='county' %}">County</a>
-        <a class="mb-1 btn btn-sm btn-outline-primary {% if authority_type == 'combined' %} active{% endif %}" href="{% include 'scoring/includes/scoring_url.html' with slug='combined' %}">Combined Authority</a>
-        <a class="mb-1 btn btn-sm btn-outline-primary {% if authority_type == 'northern-ireland' %} active{% endif %}" href="{% include 'scoring/includes/scoring_url.html' with slug='northern-ireland' %}">Northern Ireland</a>
+        <a class="mb-1 btn btn-sm btn-outline-primary {% if scoring_group.slug == 'single' %} active{% endif %}" href="{% include 'scoring/includes/scoring_url.html' with slug='single' %}">Single Tier</a>
+        <a class="mb-1 btn btn-sm btn-outline-primary {% if scoring_group.slug == 'district' %} active{% endif %}" href="{% include 'scoring/includes/scoring_url.html' with slug='district' %}">District</a>
+        <a class="mb-1 btn btn-sm btn-outline-primary {% if scoring_group.slug == 'county' %} active{% endif %}" href="{% include 'scoring/includes/scoring_url.html' with slug='county' %}">County</a>
+        <a class="mb-1 btn btn-sm btn-outline-primary {% if scoring_group.slug == 'combined' %} active{% endif %}" href="{% include 'scoring/includes/scoring_url.html' with slug='combined' %}">Combined Authority</a>
+        <a class="mb-1 btn btn-sm btn-outline-primary {% if scoring_group.slug == 'northern-ireland' %} active{% endif %}" href="{% include 'scoring/includes/scoring_url.html' with slug='northern-ireland' %}">Northern Ireland</a>
     </div>
 </form>

--- a/scoring/templates/scoring/question.html
+++ b/scoring/templates/scoring/question.html
@@ -47,14 +47,14 @@
 
     <h3 class="mt-5 mb-4" id="performance">Question performance</h3>
 
-  {% if applicable_authority_types|length > 1 %}
+  {% if applicable_scoring_groups|length > 1 %}
     <div class="bg-primary-100 p-3 border rounded">
         <label for="questions-council-name" class="fs-6 d-block mb-2">Show scores for a specific council</label>
         <input class="form-control searchbar js-question-jump-autocomplete" type="search" placeholder="Council name" aria-label="Council name" id="questions-council-name">
         <p class="mt-3 mb-2 fs-6">Or show scores by type of council</p>
         <div class="d-flex flex-wrap gap-1">
-          {% for t in applicable_authority_types %}
-            <a href="?type={{ t.description }}#performance" class="btn btn-outline-primary btn-sm is--with-label {% if t.description == authority_type %}active{% endif %}">
+          {% for t in applicable_scoring_groups %}
+            <a href="?type={{ t.description }}#performance" class="btn btn-outline-primary btn-sm is--with-label {% if t.description == scoring_group.slug %}active{% endif %}">
               {% if t.description == "single" %}
                 Single Tier
               {% elif t.description == "district" %}
@@ -72,7 +72,7 @@
     </div>
   {% endif %}
 
-  {% if authority_type and totals %}
+  {% if scoring_group and totals %}
     <div class="row mt-4 mb-n4 mb-sm-0">
       {% for t in totals %}
         <div class="col-sm mb-4 mb-sm-0">
@@ -92,9 +92,9 @@
                     </span>
                     <span>
                       {% if t.count == 1 %}
-                        {% include 'scoring/includes/scoring-group-name.html' with group=authority_type plural=0 %}
+                        {% include 'scoring/includes/scoring-group-name.html' with group=scoring_group.slug plural=0 %}
                       {% else %}
-                        {% include 'scoring/includes/scoring-group-name.html' with group=authority_type plural=1 %}
+                        {% include 'scoring/includes/scoring-group-name.html' with group=scoring_group.slug plural=1 %}
                       {% endif %}
                     </span>
                 </div>

--- a/scoring/templates/scoring/section-preview.html
+++ b/scoring/templates/scoring/section-preview.html
@@ -6,7 +6,7 @@
 {% block content %}
     <h1 class="text-shadow js-count">{{ section.description|cut:" (CA)"|prevent_widow }}</h1>
     <span class="fw-bold text-shadow subtitle">
-        {% include 'caps/includes/authority_type.html' with group=authority_type %} councils
+        {% include 'scoring/includes/scoring-group-name.html' with group=scoring_group.slug plural=True %}
     </span>
 
     <table>

--- a/scoring/templates/scoring/section.html
+++ b/scoring/templates/scoring/section.html
@@ -329,11 +329,11 @@
                 <td data-column="score" class="text-start text-md-end d-flex flex-row d-md-table-cell align-items-center score">
                     <span class="me-2">{{ question.scored_max }} out of {{ council_count }}</span>
                     <span class="fs-8 mt-1 me-0 ms-auto d-block">
-                        {% include 'caps/includes/authority_type.html' with group=council_type %}
+                        {% include 'scoring/includes/scoring-group-name.html' with group=council_type plural=True %}
                       {% if question.details.question_type == "negative" %}
-                        councils got <strong>no penalty marks</strong> for this question.
+                        got <strong>no penalty marks</strong> for this question.
                       {% else %}
-                        councils got full marks for this question.
+                        got full marks for this question.
                       {% endif %}
                     </span>
                 </td>

--- a/scoring2022/templates/scoring2022/council.html
+++ b/scoring2022/templates/scoring2022/council.html
@@ -11,7 +11,7 @@
             {% if plan_score.top_performer %}
             <span class="top-performer hero-sub">Top Performer · </span>
             {% endif %}
-            <span class="hero-sub">{{ authority_type.name }}</span>
+            <span class="hero-sub">{{ council.get_scoring_group.name }}</span>
         </div>
     </div>
 </div>
@@ -34,7 +34,7 @@
                 <p>We do not currently have a Scorecard for this council.</p>
                 {% else %}
                 {% if plan_score.top_performer %}
-                <p class="top-performer.active mb-0">This council is a top performer within {% include 'caps/includes/authority_type.html' with group=authority_type %} councils.</p>
+                <p class="top-performer.active mb-0">This council is a top performer among {% include 'scoring/includes/scoring-group-name.html' with group=council.get_scoring_group.slug plural=True %}.</p>
                 {% endif %}
                 <a href="{% include 'scoring2022/includes/scoring_url.html' with slug=council.get_scoring_group.slug %}">See council in context</a>
                 <div class="group-label-wrapper mt-3">
@@ -162,7 +162,7 @@
                               {% for comparison in comparisons %}
                                 <th scope="col">{{ comparison.council.name }}</th>
                               {% endfor %}
-                                <th scope="col">Average {% include 'caps/includes/authority_type.html' with group=authority_type %} council score</th>
+                                <th scope="col">Average {% include 'scoring/includes/scoring-group-name.html' with group=council.get_scoring_group.slug plural=False %} score</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -249,7 +249,7 @@
                                 </td>
                               {% endfor %}
                                 <td class="top-tier-score">
-                                  <a href="{% include 'scoring2022/includes/scoring_url.html' with slug=authority_type.slug %}?sort_by={{ section.code }}" class="mx-auto" style="text-transform: none">{{ section.max_count }} out of {{ council_count }}</a> <span>{% include 'caps/includes/authority_type.html' with group=authority_type %} councils got full marks for this section.</span>
+                                  <a href="{% include 'scoring2022/includes/scoring_url.html' with slug=council.get_scoring_group.slug %}?sort_by={{ section.code }}" class="mx-auto" style="text-transform: none">{{ section.max_count }} out of {{ council_count }}</a> <span>{% include 'scoring/includes/scoring-group-name.html' with group=council.get_scoring_group.slug plural=True %} got full marks for this section.</span>
                                 </td>
                                 <td class="button-wrapper p-0">
                                     <button type="button" class="accordion js-toggle-council-question-table-section" aria-label="Expand this section" title="Expand this section">
@@ -307,7 +307,7 @@
                               {% endfor %}
                               {% endif %}
                               <td class="top-tier-score">
-                                <a href="{% include 'scoring2022/includes/scoring_url.html' with slug=authority_type.slug %}?sort_by={{ section.code }}" class="mx-auto" style="text-transform: none">{{ answer.council_count }} out of {{ council_count }}</a> <span>{% include 'caps/includes/authority_type.html' with group=authority_type %} councils got full marks for this question.</span>
+                                <a href="{% include 'scoring2022/includes/scoring_url.html' with slug=council.get_scoring_group.slug %}?sort_by={{ section.code }}" class="mx-auto" style="text-transform: none">{{ answer.council_count }} out of {{ council_count }}</a> <span>{% include 'scoring/includes/scoring-group-name.html' with group=council.get_scoring_group.slug plural=True %} got full marks for this question.</span>
                                 </td>
                             </tr>
                           {% endfor %}

--- a/scoring2022/views.py
+++ b/scoring2022/views.py
@@ -102,7 +102,9 @@ class HomePageView(PrivateScorecardsAccessMixin, AdvancedFilterMixin, FilterView
         context = self.setup_filter_context(context, context["filter"], authority_type)
 
         averages = PlanSection.get_average_scores(
-            authority_type["slug"], filter=context.get("filter_params", None), year=2021
+            scoring_group=authority_type,
+            filter=context.get("filter_params", None),
+            year=2021,
         )
         all_scores = PlanSectionScore.get_all_council_scores(plan_year=2021)
 


### PR DESCRIPTION
Fixes #611.

Adds an "Advanced filter" for `authority_type`, on the Single Tier scorecard.

<img width="717" alt="Screenshot 2024-11-15 at 18 50 39" src="https://github.com/user-attachments/assets/56782f59-b6a5-4487-8d80-00d73f4eaf33">

While I was there, I also fixed a long-standing code smell, where we had been using `authority_type` to refer to both _actual_ MapIt council authority types (eg: "UTA", "DIS", "CTY") and Scorecards scoring groups (eg: "single-tier").

This makes the PR look much more complex than it actually is. Best to review each commit separately!