### PR TITLE
Council table fixes

### DIFF
--- a/scoring/static/scoring/scss/table-question-council.scss
+++ b/scoring/static/scoring/scss/table-question-council.scss
@@ -31,6 +31,10 @@
             background: lighten($color-scorecard-yellow, 30%) !important;
         }
     }
+
+    .how-is-marked-section {
+        max-width: 350px;
+    }
 }
 
 .top-tier-score {

--- a/scoring/templates/scoring/includes/question-content-table-cell.html
+++ b/scoring/templates/scoring/includes/question-content-table-cell.html
@@ -28,7 +28,7 @@
                 </button>
             </div>
 
-            <div class="text-muted fs-7" id="section-{{ forloop.parentloop.counter }}-question-{{ forloop.counter }}" hidden="true">
+            <div class="text-muted fs-7 how-is-marked-section" id="section-{{ forloop.parentloop.counter }}-question-{{ forloop.counter }}" hidden="true">
                 <dl class="row mt-3 mb-0">
                     <dt class="col-sm-4">Source</dt>
                     <dd class="col-sm-8">{{ how_marked }}</dd>

--- a/scoring/templates/scoring/includes/question-content-table-cell.html
+++ b/scoring/templates/scoring/includes/question-content-table-cell.html
@@ -4,20 +4,18 @@
             <span class="badge bg-secondary p-1 question-no">{{ pretty_code }}</span>
         </div>
         <div class="col-11">
-            <a href="{% url 'scoring:question' code %}{% if council %}?type={{ council_type_slug }}{% endif %}">
-                {{ question_text.strip | linebreaks }}
-            </a>
+            {{ question_text.strip | linebreaks }}
 
-          {% if question_type == "negative" %}
-            <div class="d-flex mb-3 fs-7 text-red-500">
-                {% include 'caps/icons/warning.html' with classes='mt-1 me-2 flex-shrink-0 flex-grow-0' width='1em' height='1em' role='presentation' %}
-                <p class="mb-0">
-                    <strong>Penalty marks:</strong>
-                    The maximum number of points for this question is 0.
-                    <a href="{% url 'year_scoring:methodology' plan_year %}#section-question-weighting-within" style="color: inherit;">Read more about penalty mark questions.</a>
-                </p>
-            </div>
-          {% endif %}
+            {% if question_type == "negative" %}
+                <div class="d-flex mb-3 fs-7 text-red-500">
+                    {% include 'caps/icons/warning.html' with classes='mt-1 me-2 flex-shrink-0 flex-grow-0' width='1em' height='1em' role='presentation' %}
+                    <p class="mb-0">
+                        <strong>Penalty marks:</strong>
+                        The maximum number of points for this question is 0.
+                        <a href="{% url 'year_scoring:methodology' plan_year %}#section-question-weighting-within" style="color: inherit;">Read more about penalty mark questions.</a>
+                    </p>
+                </div>
+            {% endif %}
 
             <div class="d-flex align-items-center gap-3">
                 <button type="button" class="btn btn-outline-secondary btn-sm js-hidden-toggle" aria-controls="section-{{ forloop.parentloop.counter }}-question-{{ forloop.counter }}">
@@ -26,9 +24,10 @@
                 <button type="button" class="btn btn-outline-secondary btn-sm" data-bs-toggle="modal" data-bs-target="#criteria-section-{{ forloop.parentloop.counter }}-question-{{ forloop.counter }}">
                     View criteria
                 </button>
+                <a href="{% url 'scoring:question' code %}{% if council %}?type={{ council_type_slug }}{% endif %}">Visit question &#8594;</a>
             </div>
 
-            <div class="text-muted fs-7 how-is-marked-section" id="section-{{ forloop.parentloop.counter }}-question-{{ forloop.counter }}" hidden="true">
+            <div class="text-muted fs-7" id="section-{{ forloop.parentloop.counter }}-question-{{ forloop.counter }}" hidden="true">
                 <dl class="row mt-3 mb-0">
                     <dt class="col-sm-4">Source</dt>
                     <dd class="col-sm-8">{{ how_marked }}</dd>


### PR DESCRIPTION
Added "Visit question" link to question cell:
<img width="1262" alt="Screenshot 2025-02-11 at 14 08 12" src="https://github.com/user-attachments/assets/526e4ed0-4546-450b-93bf-88ca46e57eb6" />


This PR also fixes the horizontal scrolling/overflowing when you press "How is this marked?" on mobile.
