### PR TITLE
[Scorecards] Added year comparison question page

### DIFF
--- a/caps/templates/caps/icons/arrow-down.html
+++ b/caps/templates/caps/icons/arrow-down.html
@@ -1,0 +1,2 @@
+<svg width="{{ width | default:'1em' }}" height="{{ height | default:'1em' }}" viewBox="0 0 30 30" class="bi {{ classes }}" {% if role %}role="{{ role }}"{% endif %} fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M29 15L15 29L1 15L9.84211 15L9.84211 1L20.1579 1L20.1579 15L29 15Z" fill="white" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/caps/templates/caps/icons/arrow-up.html
+++ b/caps/templates/caps/icons/arrow-up.html
@@ -1,0 +1,2 @@
+<svg width="{{ width | default:'1em' }}" height="{{ height | default:'1em' }}" viewBox="0 0 30 30" class="bi {{ classes }}" {% if role %}role="{{ role }}"{% endif %} fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1 15L15 1L29 15H20.1579V29H9.84211V15H1Z" fill="currentColor" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>

--- a/scoring/static/scoring/js/main.js
+++ b/scoring/static/scoring/js/main.js
@@ -590,3 +590,53 @@ document.querySelectorAll('.js-social-graphic-download').forEach(function(el) {
         });
     });
 });
+
+// Question display improved or worsened councils
+// Function to update table visibility based on checkbox states
+function updateTableVisibility() {
+    var improvedChecked = document.querySelector('.js-checkbox-improved-councils').checked;
+    var worsenedChecked = document.querySelector('.js-checkbox-worsened-councils').checked;
+    
+    // If no checkboxes are checked, show all rows
+    var showAll = !improvedChecked && !worsenedChecked;
+    
+    // Update visibility for rows with year-difference-status
+    forEachElement('tr[year-difference-status]', function(row) {
+        var status = row.getAttribute('year-difference-status');
+        
+        // Show the row if:
+        // 1. No filters are active (show all)
+        // 2. The row's status matches the active filter
+        if (showAll || 
+            (improvedChecked && status === 'improved') || 
+            (worsenedChecked && status === 'worsened')) {
+            row.style.display = '';
+        } else {
+            row.style.display = 'none';
+        }
+    });
+}
+
+forEachElement('.js-checkbox-improved-councils', function(checkbox) {
+    checkbox.addEventListener('change', function() {
+        // If this checkbox is checked, uncheck the other one
+        if (this.checked) {
+            forEachElement('.js-checkbox-worsened-councils', function(otherCheckbox) {
+                otherCheckbox.checked = false;
+            });
+        }
+        updateTableVisibility();
+    });
+});
+
+forEachElement('.js-checkbox-worsened-councils', function(checkbox) {
+    checkbox.addEventListener('change', function() {
+        // If this checkbox is checked, uncheck the other one
+        if (this.checked) {
+            forEachElement('.js-checkbox-improved-councils', function(otherCheckbox) {
+                otherCheckbox.checked = false;
+            });
+        }
+        updateTableVisibility();
+    });
+});

--- a/scoring/static/scoring/scss/table-question-council.scss
+++ b/scoring/static/scoring/scss/table-question-council.scss
@@ -1,8 +1,20 @@
+.question-summary-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(10rem, 10rem));
+    column-gap: 1rem;
+    row-gap: 1rem;
+
+    @include media-breakpoint-up(lg) {
+        grid-template-columns: repeat(auto-fill, minmax(12.5rem, 13.5rem));
+        column-gap: 2rem;
+    }
+}
+
 .table-question-council,
 .section-question-table,
 .table-council-question-performance {
     th {
-        vertical-align: top;
+        vertical-align: middle;
     }
 
     th, td  {

--- a/scoring/static/scoring/scss/variables.scss
+++ b/scoring/static/scoring/scss/variables.scss
@@ -254,6 +254,8 @@ $form-select-indicator: url("../img/bootstrap/form-select-indicator.svg");
 $form-feedback-icon-valid: url("../img/bootstrap/form-feedback-icon-valid.svg");
 $form-feedback-icon-invalid: url("../img/bootstrap/form-feedback-icon-invalid.svg");
 
+$form-check-input-border: 1px solid rgba($black, .5);
+
 // Form validation
 
 // Z-index master list

--- a/scoring/templates/scoring/question.html
+++ b/scoring/templates/scoring/question.html
@@ -102,84 +102,88 @@
                             {% endif %}
                         </span>
                     </div>
-                    {% comment %} TODO: Add a conditional for the .card-footer, if question didn't exist in 2023 then it won't get displayed. {% endcomment %}
-                    <div class="card-footer d-flex flex-row justify-content-between">
-                        <div>
-                            {% comment %} TODO: add 2023 council numbers {% endcomment %}
-                            <span class="fs-5 lh-1">122</span>
-                            <span class="fs-8">in 2023</span>
-                        </div>
-                        <div>
-                            {% comment %} TODO: add difference between 2023 and 2025 {% endcomment %}
-                            <span class="fs-5 lh-1"><span class="fs-7">&#9650;</span>12</span>
-                        </div>
-                    </div>
+                    {% if previous_year %}
+                        {% if not no_comparison and not max_score_changed  %}
+                            <div class="card-footer d-flex flex-row justify-content-between">
+                                <div>
+                                    <span class="fs-5 lh-1">{{ t.prev_count }}</span>
+                                    <span class="fs-8">in {{ previous_year }}</span>
+                                </div>
+                                <div>
+                                    <span class="fs-5 lh-1"><span class="fs-7">{% if t.change > 0 %}&#9650;{% elif t.change < 0 %}&#9660;{% endif %}</span>{{ t.change }}</span>
+                                </div>
+                            </div>
+                        {% endif %}
+                    {% endif %}
                 </div>
             </div>
         {% endfor %}
         </div>
 
-        {% comment %} TODO This section should only be displayed if there is a comparison between 2023 and 2025 {% endcomment %}
-        <h3 class="h4 mb-1 mt-5">Performance comparison between 2023 and 2025</h3>
-        <p class="text-capitalize mb-3 fs-5">{% include 'scoring/includes/scoring-group-name.html' with group=scoring_group.slug plural=1 %}</p>
-        <div class="d-flex flex-row flex-wrap gap-3 mt-3">
-            <div class="card overflow-hidden">
-                <div class="card-body bg-green-600 text-light d-flex flew-row flex-nowrap gap-1">
-                    <div class="d-flex align-items-baseline">
-                        {% include 'caps/icons/arrow-up.html' with classes='opacity-50 d-none d-md-block' width='2.5rem' height='2.5rem' role='presentation' %}
-                        <span class="display-3 d-none d-md-block fw-bold lh-1">35</span>
-                        {% include 'caps/icons/arrow-up.html' with classes='opacity-50 d-md-none' width='1.75rem' height='1.75rem' role='presentation' %}
-                        <span class="d-md-none display-1 fw-bold lh-1 mt-1">35</span>
-                    </div>
-                    <div class="d-flex flex-column">
-                        <span class="display-6 lh-1">councils</span>
-                        <span class="lh-1">scored higher in 2025</span>
-                    </div>
+        {% if previous_year %} 
+            {% if max_score_changed %}
+                <div class="alert alert-dark mt-3 w-md-50" role="alert">
+                    <h3 class="h5">Score comparison unavailable</h3>
+                    <p class="mb-0">There is no comparison between {{ plan_year }} and {{ previous_year }} data because this question's maximum score was modified in {{ plan_year }}.</p>
                 </div>
-                <div class="card-footer bg-green-100 text-dark">
-                    <div class="form-check">
-                        <input class="form-check-input js-checkbox-improved-councils" type="checkbox" value="" id="checkbox-improved-councils">
-                        <label class="form-check-label" for="checkbox-improved-councils">
-                          Show councils
-                        </label>
-                    </div>
+            {% elif no_comparison %}
+                <div class="alert alert-dark mt-3 w-md-50" role="alert">
+                    <h3 class="h5">Score comparison unavailable</h3>
+                    <p class="mb-0">This question was introduced in the {{ plan_year }} Action Scorecards and has no historical data for comparison.</p>
                 </div>
-            </div>
+            {% else %}
+                <h3 class="h4 mb-1 mt-5">Performance comparison between {{ previous_year }} and {{ plan_year }}</h3>
+                <p class="text-capitalize mb-3 fs-5">{% include 'scoring/includes/scoring-group-name.html' with group=scoring_group.slug plural=1 %}</p>
+                <div class="d-flex flex-row flex-wrap gap-3 mt-3">
+                    <div class="card overflow-hidden">
+                        <div class="card-body bg-green-600 text-light d-flex flew-row flex-nowrap gap-1">
+                            <div class="d-flex align-items-baseline">
+                                {% include 'caps/icons/arrow-up.html' with classes='opacity-50 d-none d-md-block' width='2.5rem' height='2.5rem' role='presentation' %}
+                                <span class="display-3 d-none d-md-block fw-bold lh-1">{{ increased }}</span>
+                                {% include 'caps/icons/arrow-up.html' with classes='opacity-50 d-md-none' width='1.75rem' height='1.75rem' role='presentation' %}
+                                <span class="d-md-none display-1 fw-bold lh-1 mt-1">{{ increased }}</span>
+                            </div>
+                            <div class="d-flex flex-column">
+                                <span class="display-6 lh-1">councils</span>
+                                <span class="lh-1">scored higher in {{ plan_year }}</span>
+                            </div>
+                        </div>
+                        <div class="card-footer bg-green-100 text-dark">
+                            <div class="form-check">
+                                <input class="form-check-input js-checkbox-improved-councils" type="checkbox" value="" id="checkbox-improved-councils">
+                                <label class="form-check-label" for="checkbox-improved-councils">
+                                  Show councils
+                                </label>
+                            </div>
+                        </div>
+                    </div>
 
-            <div class="card overflow-hidden">
-                <div class="card-body bg-red-600 text-light d-flex flew-row flex-nowrap gap-1">
-                    <div class="d-flex align-items-baseline">
-                        {% include 'caps/icons/arrow-down.html' with classes='opacity-50 d-none d-md-block' width='2.5rem' height='2.5rem' role='presentation' %}
-                        <span class="display-3 d-none d-md-block fw-bold lh-1">5</span>
-                        {% include 'caps/icons/arrow-down.html' with classes='opacity-50 d-md-none' width='1.75rem' height='1.75rem' role='presentation' %}
-                        <span class="d-md-none display-1 fw-bold lh-1 mt-1">5</span>
-                    </div>
-                    <div class="d-flex flex-column">
-                        <span class="display-6 lh-1">councils</span>
-                        <span class="lh-1">scored lower in 2025</span>
+                    <div class="card overflow-hidden">
+                        <div class="card-body bg-red-600 text-light d-flex flew-row flex-nowrap gap-1">
+                            <div class="d-flex align-items-baseline">
+                                {% include 'caps/icons/arrow-down.html' with classes='opacity-50 d-none d-md-block' width='2.5rem' height='2.5rem' role='presentation' %}
+                                <span class="display-3 d-none d-md-block fw-bold lh-1">{{ decreased }}</span>
+                                {% include 'caps/icons/arrow-down.html' with classes='opacity-50 d-md-none' width='1.75rem' height='1.75rem' role='presentation' %}
+                                <span class="d-md-none display-1 fw-bold lh-1 mt-1">{{ decreased }}</span>
+                            </div>
+                            <div class="d-flex flex-column">
+                                <span class="display-6 lh-1">councils</span>
+                                <span class="lh-1">scored lower in {{ plan_year }}</span>
+                            </div>
+                        </div>
+                        <div class="card-footer bg-red-100 text-dark">
+                            <div class="form-check">
+                                <input class="form-check-input js-checkbox-worsened-councils" type="checkbox" value="" id="checkbox-worsened-councils">
+                                <label class="form-check-label" for="checkbox-worsened-councils">
+                                  Show councils
+                                </label>
+                            </div>
+                        </div>
                     </div>
                 </div>
-                <div class="card-footer bg-red-100 text-dark">
-                    <div class="form-check">
-                        <input class="form-check-input js-checkbox-worsened-councils" type="checkbox" value="" id="checkbox-worsened-councils">
-                        <label class="form-check-label" for="checkbox-worsened-councils">
-                          Show councils
-                        </label>
-                    </div>
-                </div>
-            </div>
-        </div>
+            {% endif %}
+        {% endif %}
 
-        {% comment %} TODO: if there are changes between scores display the following message: {% endcomment %}
-        <div class="alert alert-dark mt-3 w-md-50" role="alert">
-            <h3 class="h5">Score comparison unavailable</h3>
-            <p class="mb-0">There is no comparison between 2025 and 2023 data because this question's maximum score was modified in 2025.</p>
-        </div>
-        {% comment %} TODO: if new 2025 question display this: {% endcomment %}
-        <div class="alert alert-dark mt-3 w-md-50" role="alert">
-            <h3 class="h5">Score comparison unavailable</h3>
-            <p class="mb-0">This question was introduced in the 2025 Action Scorecards and has no historical data for comparison.</p>
-        </div>
     {% endif %}
 
     {% if scores %}
@@ -188,15 +192,21 @@
                 <tr>
                     <th scope="col" class="text-start border-end border-opacity-25 border-primary">Council</th>
                     <th scope="col" class="d-none d-md-table-cell text-center border-end border-opacity-25 border-primary">Score</th>
-                    {% comment %} TODO only to be displayed if there is a 2023 comparison {% endcomment %}
-                    <th scope="col" class="d-none d-md-table-cell text-center border-end border-opacity-25 border-primary"><span class="d-block mb-0 lh-1">Difference </span><span class="fs-8 lh-1">2023</span></th>
+                    {% if display_comparison %}
+                    <th scope="col" class="d-none d-md-table-cell text-center border-end border-opacity-25 border-primary"><span class="d-block mb-0 lh-1">Difference </span><span class="fs-8 lh-1">{{ previous_year }}</span></th>
+                    {% endif %}
                     <th scope="col" class="d-none d-md-table-cell text-start border-end border-opacity-25 border-primary">Evidence</th>
                 </tr>
             </thead>
             <tbody>
                 {% for score in scores %}
-                {% comment %} TODO: Replace 'year-difference' for the actual value {% endcomment %}
+                    {% if score.change and score.change > 0 %}
                     <tr data-jump-slug="{{ score.plan_score.council.slug }}" year-difference-status="improved">
+                    {% elif score.change and score.change < 0 %}
+                    <tr data-jump-slug="{{ score.plan_score.council.slug }}" year-difference-status="worsened">
+                    {% else %}
+                    <tr data-jump-slug="{{ score.plan_score.council.slug }}" year-difference-status="unchanged">
+                    {% endif %}
                         <td class="text-start border-bottom border-start border-end border-opacity-25 border-primary vertical-align-middle">
                             <a class="fs-5 d-block mb-3 mb-md-0" href="{% url 'scoring:council' score.plan_score.council.slug %}">
                                 {{ score.plan_score.council.name }}
@@ -206,15 +216,19 @@
                             <div class="d-md-none overflow-hidden" style="max-width: 18.75rem">
                                 <dl class="d-flex flex-row gap-5 mb-2">
                                     <div>
-                                        <dt class="fs-8 text-uppercase text-muted mb-0">Score 2025</dt>
+                                        <dt class="fs-8 text-uppercase text-muted mb-0">Score {{ plan_year }}</dt>
                                         <dd>{{ score.score|floatformat:"-2" }}/{{ score.max_score }}</dd>
                                     </div>
 
                                     <div>
-                                        <dt class="fs-8 text-uppercase text-muted mb-0">2023 Difference</dt>
-                                        {% comment %} TODO If difference is negative: change replace &#9650; with &#9660; {% endcomment %}
-                                        {% comment %} TODO If difference is negative: change text-success to text-warning {% endcomment %}
-                                        <dd class="text-success"> &#9650; {{ score.score|floatformat:"-2" }}</dd>
+                                        <dt class="fs-8 text-uppercase text-muted mb-0">{{ previous_year }} Difference</dt>
+                                        {% if score.change > 0 %}
+                                            <dd class="text-success"> &#9650; {{ score.score|floatformat:"-2" }}</dd>
+                                        {% elif score.change < 0 %}
+                                            <dd class="text-warning"> &#9660; {{ score.score|floatformat:"-2" }}</dd>
+                                        {% elif score.change == 0 %}
+                                            <dd class="text-grey-100"> -- </dd>
+                                        {% endif %}
                                     </div>
                                 </dl>
                                 {% if score.score != 0 %}
@@ -236,12 +250,21 @@
                         <td class="d-none d-md-table-cell text-center border-bottom border-end border-opacity-25 border-primary {% if score.score < 0 %}bg-red-100{% endif %}">
                             {{ score.score|floatformat:"-2" }}/{{ score.max_score }}
                         </td>
-                        {% comment %} TODO only to be displayed if there is a 2023 comparison {% endcomment %}
-                        {% comment %} TODO If difference is negative: change replace &#9650; with &#9660; {% endcomment %}
-                        {% comment %} TODO If difference is negative: change text-success to text-warning {% endcomment %}
-                        <td class="d-none d-md-table-cell text-success text-center border-bottom border-end border-opacity-25 border-primary">
-                            &#9650; {{ score.score|floatformat:"-2" }}
-                        </td>
+                        {% if display_comparison %}
+                            {% if score.change > 0 %}
+                            <td class="d-none d-md-table-cell text-success text-center border-bottom border-end border-opacity-25 border-primary">
+                                &#9650; {{ score.change|floatformat:"-2" }}
+                            </td>
+                            {% elif score.change < 0 %}
+                            <td class="d-none d-md-table-cell text-warning text-center border-bottom border-end border-opacity-25 border-primary">
+                                &#9660; {{ score.change|floatformat:"-2" }}
+                            </td>
+                            {% elif score.change == 0 %}
+                            <td class="d-none d-md-table-cell text-grey-100 text-center border-bottom border-end border-opacity-25 border-primary">
+                                --
+                            </td>
+                            {% endif %}
+                        {% endif %}
                         <td class="d-none d-md-table-cell text-start border-bottom border-end border-opacity-25 border-primary">
                             {% if score.score != 0 %}
                             <ul class="ps-3">

--- a/scoring/templates/scoring/question.html
+++ b/scoring/templates/scoring/question.html
@@ -5,8 +5,8 @@
 <div class="pt-5 pb-6 pt-lg-8 pb-lg-8 hero-section with-version-background">
     {% include 'scoring/includes/scorecards_year.html' %}
     <div class="container">
-        <h2 class="fs-4">Action Scorecards {{ plan_year }}</h2>
-        <h1 class="mb-2">Question: {{ question.text }}</h1>
+        <p class="fs-4">Question · Action Scorecards {{ plan_year }}</p>
+        <h1 class="mb-2 w-lg-75 h2">{{ question.text }}</h1>
         <dl class="row mt-4 mb-0" style="max-width: 30em">
             <dt class="col-sm-4">Question code</dt>
             <dd class="col-sm-8">{{ question.pretty_code }}</dd>
@@ -20,7 +20,7 @@
             <dd class="col-sm-8">{{ question.get_how_marked_display }}</dd>
             <dt class="col-sm-4">Question weight</dt>
             <dd class="col-sm-8">
-                <a href="{% url 'year_scoring:methodology' plan_year %}#section-question-weighting-within" class="d-inline-flex align-items-center" title="Read more about question weighting within sections">
+                <a href="{% url 'year_scoring:methodology' plan_year %}#section-question-weighting-within" data-bs-toggle="tooltip" data-bs-placement="top" class="d-inline-flex align-items-center" title="Read more about question weighting within sections">
                     {{ question.get_weighting_display }}
                     {% include 'caps/icons/question-circle.html' with classes='ms-2 align-text-top' width='1rem' height='1rem' role='presentation' %}
                 </a>
@@ -32,45 +32,49 @@
 <div class="container py-5 py-lg-6">
     <div class="row gx-lg-5 gx-xl-6">
         <div class="col-md-6">
-            <h3>Criteria</h3>
-          {% autoescape off %}
-            {{ question.criteria|linebreaks|urlize }}
-          {% endautoescape %}
+            <h2 class="h3">Criteria</h2>
+            {% autoescape off %}
+              {{ question.criteria|linebreaks|urlize }}
+            {% endautoescape %}
         </div>
         <div class="col-md-6 mt-5 mt-md-0">
-            <h3>Clarifications</h3>
-          {% autoescape off %}
-            {{ question.clarifications|linebreaks|urlize }}
-          {% endautoescape %}
+            <h2 class="h3">Clarifications</h2>
+            {% autoescape off %}
+              {{ question.clarifications|linebreaks|urlize }}
+            {% endautoescape %}
         </div>
     </div>
 
-    <h3 class="mt-5 mb-4" id="performance">Question performance</h3>
+    <div class="row">
+        <div class="col-md-6">
+              <h2 class="h3 mt-5 mb-4" id="performance">Question performance</h2>
 
-  {% if applicable_scoring_groups|length > 1 %}
-    <div class="bg-primary-100 p-3 border rounded">
-        <label for="questions-council-name" class="fs-6 d-block mb-2">Show scores for a specific council</label>
-        <input class="form-control searchbar js-question-jump-autocomplete" type="search" placeholder="Council name" aria-label="Council name" id="questions-council-name">
-        <p class="mt-3 mb-2 fs-6">Or show scores by type of council</p>
-        <div class="d-flex flex-wrap gap-1">
-          {% for t in applicable_scoring_groups %}
-            <a href="?type={{ t.description }}#performance" class="btn btn-outline-primary btn-sm is--with-label {% if t.description == scoring_group.slug %}active{% endif %}">
-              {% if t.description == "single" %}
-                Single Tier
-              {% elif t.description == "district" %}
-                District
-              {% elif t.description == "county" %}
-                County
-              {% elif t.description == "northern-ireland" %}
-                Northern Ireland
-              {% elif t.description == "combined" %}
-                Combined Authority
+              {% if applicable_scoring_groups|length > 1 %}
+              <div class="bg-primary-100 p-3 border rounded">
+                    <label for="questions-council-name" class="fs-6 d-block mb-2">Show scores for a specific council</label>
+                    <input class="form-control searchbar js-question-jump-autocomplete" type="search" placeholder="Council name" aria-label="Council name" id="questions-council-name">
+                    <p class="mt-3 mb-2 fs-6">Or show scores by type of council</p>
+                    <div class="d-flex flex-wrap gap-1">
+                        {% for t in applicable_scoring_groups %}
+                            <a href="?type={{ t.description }}#performance" class="btn btn-outline-primary btn-sm is--with-label {% if t.description == scoring_group.slug %}active{% endif %}">
+                              {% if t.description == "single" %}
+                                Single Tier
+                              {% elif t.description == "district" %}
+                                District
+                              {% elif t.description == "county" %}
+                                County
+                              {% elif t.description == "northern-ireland" %}
+                                Northern Ireland
+                              {% elif t.description == "combined" %}
+                                Combined Authority
+                              {% endif %}
+                            </a>
+                        {% endfor %}
+                    </div>
+              </div>
               {% endif %}
-            </a>
-          {% endfor %}
         </div>
     </div>
-  {% endif %}
 
   {% if scoring_group and totals %}
     <div class="row mt-4 mb-n4 mb-sm-0">

--- a/scoring/templates/scoring/question.html
+++ b/scoring/templates/scoring/question.html
@@ -76,74 +76,191 @@
         </div>
     </div>
 
-  {% if scoring_group and totals %}
-    <div class="row mt-4 mb-n4 mb-sm-0">
-      {% for t in totals %}
-        <div class="col-sm mb-4 mb-sm-0">
-            <div class="card h-100">
-                <div class="card-header py-3 text-bg-primary">
-                    <h3 class="fs-4 mb-0 text-center">
-                      {% if question.is_negatively_marked and t.score == 0 %}
-                        Councils without penalty marks
-                      {% else %}
-                        {{ t.score|floatformat:0 }} point{{ t.score|pluralize }}
-                      {% endif %}
-                    </h3>
+    {% if scoring_group and totals %}
+        <div class="question-summary-grid mt-5">
+        {% for t in totals %}
+            <div class="question-summary-grid__item">
+                <div class="card">
+                    <div class="card-header bg-primary text-light">
+                        <h3 class="fs-4 mb-0 text-center">
+                            {% if question.is_negatively_marked and t.score == 0 %}
+                                Councils without penalty marks
+                            {% else %}
+                                {{ t.score|floatformat:0 }} point{{ t.score|pluralize }}
+                            {% endif %}
+                        </h3>
+                    </div>
+                    <div class="card-body d-flex flex-column align-items-center justify-content-center">
+                        <span class="fs-1 lh-1 {% if t.score < 0 %}text-warning{% endif %}">
+                            {{ t.count }}
+                        </span>
+                        <span class="lh-sm text-center">
+                            {% if t.count == 1 %}
+                                {% include 'scoring/includes/scoring-group-name.html' with group=scoring_group.slug plural=0 %}
+                            {% else %}
+                                {% include 'scoring/includes/scoring-group-name.html' with group=scoring_group.slug plural=1 %}
+                            {% endif %}
+                        </span>
+                    </div>
+                    {% comment %} TODO: Add a conditional for the .card-footer, if question didn't exist in 2023 then it won't get displayed. {% endcomment %}
+                    <div class="card-footer d-flex flex-row justify-content-between">
+                        <div>
+                            {% comment %} TODO: add 2023 council numbers {% endcomment %}
+                            <span class="fs-5 lh-1">122</span>
+                            <span class="fs-8">in 2023</span>
+                        </div>
+                        <div>
+                            {% comment %} TODO: add difference between 2023 and 2025 {% endcomment %}
+                            <span class="fs-5 lh-1"><span class="fs-7">&#9650;</span>12</span>
+                        </div>
+                    </div>
                 </div>
-                <div class="card-body d-flex flex-column align-items-center justify-content-center text-center {% if t.score < 0 %}bg-red-100{% endif %}">
-                    <span class="fs-1 lh-1 mb-2">
-                        {{ t.count }}
-                    </span>
-                    <span>
-                      {% if t.count == 1 %}
-                        {% include 'scoring/includes/scoring-group-name.html' with group=scoring_group.slug plural=0 %}
-                      {% else %}
-                        {% include 'scoring/includes/scoring-group-name.html' with group=scoring_group.slug plural=1 %}
-                      {% endif %}
-                    </span>
+            </div>
+        {% endfor %}
+        </div>
+
+        {% comment %} TODO This section should only be displayed if there is a comparison between 2023 and 2025 {% endcomment %}
+        <h3 class="h4 mb-1 mt-5">Performance comparison between 2023 and 2025</h3>
+        <p class="text-capitalize mb-3 fs-5">{% include 'scoring/includes/scoring-group-name.html' with group=scoring_group.slug plural=1 %}</p>
+        <div class="d-flex flex-row flex-wrap gap-3 mt-3">
+            <div class="card overflow-hidden">
+                <div class="card-body bg-green-600 text-light d-flex flew-row flex-nowrap gap-1">
+                    <div class="d-flex align-items-baseline">
+                        {% include 'caps/icons/arrow-up.html' with classes='opacity-50 d-none d-md-block' width='2.5rem' height='2.5rem' role='presentation' %}
+                        <span class="display-3 d-none d-md-block fw-bold lh-1">35</span>
+                        {% include 'caps/icons/arrow-up.html' with classes='opacity-50 d-md-none' width='1.75rem' height='1.75rem' role='presentation' %}
+                        <span class="d-md-none display-1 fw-bold lh-1 mt-1">35</span>
+                    </div>
+                    <div class="d-flex flex-column">
+                        <span class="display-6 lh-1">councils</span>
+                        <span class="lh-1">scored higher in 2025</span>
+                    </div>
+                </div>
+                <div class="card-footer bg-green-100 text-dark">
+                    <div class="form-check">
+                        <input class="form-check-input js-checkbox-improved-councils" type="checkbox" value="" id="checkbox-improved-councils">
+                        <label class="form-check-label" for="checkbox-improved-councils">
+                          Show councils
+                        </label>
+                    </div>
+                </div>
+            </div>
+
+            <div class="card overflow-hidden">
+                <div class="card-body bg-red-600 text-light d-flex flew-row flex-nowrap gap-1">
+                    <div class="d-flex align-items-baseline">
+                        {% include 'caps/icons/arrow-down.html' with classes='opacity-50 d-none d-md-block' width='2.5rem' height='2.5rem' role='presentation' %}
+                        <span class="display-3 d-none d-md-block fw-bold lh-1">5</span>
+                        {% include 'caps/icons/arrow-down.html' with classes='opacity-50 d-md-none' width='1.75rem' height='1.75rem' role='presentation' %}
+                        <span class="d-md-none display-1 fw-bold lh-1 mt-1">5</span>
+                    </div>
+                    <div class="d-flex flex-column">
+                        <span class="display-6 lh-1">councils</span>
+                        <span class="lh-1">scored lower in 2025</span>
+                    </div>
+                </div>
+                <div class="card-footer bg-red-100 text-dark">
+                    <div class="form-check">
+                        <input class="form-check-input js-checkbox-worsened-councils" type="checkbox" value="" id="checkbox-worsened-councils">
+                        <label class="form-check-label" for="checkbox-worsened-councils">
+                          Show councils
+                        </label>
+                    </div>
                 </div>
             </div>
         </div>
-      {% endfor %}
-    </div>
-  {% endif %}
 
-  {% if scores %}
-    <table class="table-council-question-performance w-100 mt-4">
-        <thead class="text-bg-primary position-sticky z-index-3 top-0">
-            <tr>
-                <th scope="col" class="text-start border-end border-opacity-25 border-primary">Council</th>
-                <th scope="col" class="text-center border-end border-opacity-25 border-primary">Score</th>
-                <th scope="col" class="text-start border-end border-opacity-25 border-primary">Evidence</th>
-            </tr>
-        </thead>
-        <tbody>
-          {% for score in scores %}
-            <tr data-jump-slug="{{ score.plan_score.council.slug }}">
-                <td class="text-start border-bottom border-start border-end border-opacity-25 border-primary">
-                    <a href="{% url 'scoring:council' score.plan_score.council.slug %}">
-                        {{ score.plan_score.council.name }}
-                    </a>
-                </td>
-                <td class="text-center border-bottom border-end border-opacity-25 border-primary {% if score.score < 0 %}bg-red-100{% endif %}">
-                    {{ score.score|floatformat:"-2" }}/{{ score.max_score }}
-                </td>
-                <td class="text-start border-bottom border-end border-opacity-25 border-primary">
-                  {% if score.score != 0 %}
-                    {% for evidence_link in score.evidence_links_cleaned %}
-                      {% if not forloop.first %}<br>{% endif %}
-                      {% if evidence_link|slice:":4" == "http" %}
-                        <a href="{{ evidence_link }}">{{ evidence_link|domain_human }}</a>
-                      {% else %}
-                        {{ evidence_link }}
-                      {% endif %}
-                    {% endfor %}
-                  {% endif %}
-                </td>
-            </tr>
-          {% endfor %}
-        </tbody>
-    </table>
-  {% endif %}
+        {% comment %} TODO: if there are changes between scores display the following message: {% endcomment %}
+        <div class="alert alert-dark mt-3 w-md-50" role="alert">
+            <h3 class="h5">Score comparison unavailable</h3>
+            <p class="mb-0">There is no comparison between 2025 and 2023 data because this question's maximum score was modified in 2025.</p>
+        </div>
+        {% comment %} TODO: if new 2025 question display this: {% endcomment %}
+        <div class="alert alert-dark mt-3 w-md-50" role="alert">
+            <h3 class="h5">Score comparison unavailable</h3>
+            <p class="mb-0">This question was introduced in the 2025 Action Scorecards and has no historical data for comparison.</p>
+        </div>
+    {% endif %}
+
+    {% if scores %}
+        <table class="table-council-question-performance w-100 mt-4">
+            <thead class="text-bg-primary position-sticky z-index-3 top-0">
+                <tr>
+                    <th scope="col" class="text-start border-end border-opacity-25 border-primary">Council</th>
+                    <th scope="col" class="d-none d-md-table-cell text-center border-end border-opacity-25 border-primary">Score</th>
+                    {% comment %} TODO only to be displayed if there is a 2023 comparison {% endcomment %}
+                    <th scope="col" class="d-none d-md-table-cell text-center border-end border-opacity-25 border-primary"><span class="d-block mb-0 lh-1">Difference </span><span class="fs-8 lh-1">2023</span></th>
+                    <th scope="col" class="d-none d-md-table-cell text-start border-end border-opacity-25 border-primary">Evidence</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for score in scores %}
+                {% comment %} TODO: Replace 'year-difference' for the actual value {% endcomment %}
+                    <tr data-jump-slug="{{ score.plan_score.council.slug }}" year-difference-status="improved">
+                        <td class="text-start border-bottom border-start border-end border-opacity-25 border-primary vertical-align-middle">
+                            <a class="fs-5 d-block mb-3 mb-md-0" href="{% url 'scoring:council' score.plan_score.council.slug %}">
+                                {{ score.plan_score.council.name }}
+                            </a>
+
+                            {% comment %} Mobile version {% endcomment %}
+                            <div class="d-md-none overflow-hidden" style="max-width: 18.75rem">
+                                <dl class="d-flex flex-row gap-5 mb-2">
+                                    <div>
+                                        <dt class="fs-8 text-uppercase text-muted mb-0">Score 2025</dt>
+                                        <dd>{{ score.score|floatformat:"-2" }}/{{ score.max_score }}</dd>
+                                    </div>
+
+                                    <div>
+                                        <dt class="fs-8 text-uppercase text-muted mb-0">2023 Difference</dt>
+                                        {% comment %} TODO If difference is negative: change replace &#9650; with &#9660; {% endcomment %}
+                                        {% comment %} TODO If difference is negative: change text-success to text-warning {% endcomment %}
+                                        <dd class="text-success"> &#9650; {{ score.score|floatformat:"-2" }}</dd>
+                                    </div>
+                                </dl>
+                                {% if score.score != 0 %}
+                                    <p class="fs-8 text-uppercase text-muted mb-0 fw-bold">Evidence</p>
+                                    <ul class="ps-3">
+                                        {% for evidence_link in score.evidence_links_cleaned %}
+                                            <li>
+                                                {% if evidence_link|slice:":4" == "http" %}
+                                                    <a href="{{ evidence_link }}">{{ evidence_link|domain_human }}</a>
+                                                {% else %}
+                                                    {{ evidence_link }}
+                                                {% endif %}
+                                            </li>
+                                        {% endfor %}
+                                    </ul>
+                                {% endif %}
+                            </div>
+                        </td>
+                        <td class="d-none d-md-table-cell text-center border-bottom border-end border-opacity-25 border-primary {% if score.score < 0 %}bg-red-100{% endif %}">
+                            {{ score.score|floatformat:"-2" }}/{{ score.max_score }}
+                        </td>
+                        {% comment %} TODO only to be displayed if there is a 2023 comparison {% endcomment %}
+                        {% comment %} TODO If difference is negative: change replace &#9650; with &#9660; {% endcomment %}
+                        {% comment %} TODO If difference is negative: change text-success to text-warning {% endcomment %}
+                        <td class="d-none d-md-table-cell text-success text-center border-bottom border-end border-opacity-25 border-primary">
+                            &#9650; {{ score.score|floatformat:"-2" }}
+                        </td>
+                        <td class="d-none d-md-table-cell text-start border-bottom border-end border-opacity-25 border-primary">
+                            {% if score.score != 0 %}
+                            <ul class="ps-3">
+                                {% for evidence_link in score.evidence_links_cleaned %}
+                                    <li>
+                                        {% if evidence_link|slice:":4" == "http" %}
+                                            <a href="{{ evidence_link }}">{{ evidence_link|domain_human }}</a>
+                                        {% else %}
+                                            {{ evidence_link }}
+                                        {% endif %}
+                                    </li>
+                                {% endfor %}
+                            </ul>
+                        {% endif %}
+                        </td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    {% endif %}
 </div>
 {% endblock %}


### PR DESCRIPTION
- [ ] Confirm what will do with questions that have change their maximum scores between 2023 and 2025. My guess is we should't show any difference. Instead let's display a message below the overview cards explaining why there is no comparison.

### Desktop
https://github.com/user-attachments/assets/b302ed73-6947-49eb-8954-59f9f4b07620

### Mobile
https://github.com/user-attachments/assets/f92d3c56-970d-416b-b967-987788db55b2



