### PR TITLE
[Scorecards] Added Chevron and 'versus' to most improved graphic

### DIFF
--- a/scoring/static/scoring/scss/open-graph-preview.scss
+++ b/scoring/static/scoring/scss/open-graph-preview.scss
@@ -172,6 +172,10 @@
     td:first-child & {
         font-size: 7rem;
     }
+
+    &-up {
+        font-size: 0.8em;
+    }
 }
 
 .open-graph-preview__section {

--- a/scoring/templates/scoring/base-most-improved.html
+++ b/scoring/templates/scoring/base-most-improved.html
@@ -21,7 +21,7 @@
             <tr>
                 <th scope="col">{{ plan_year }} score</th>
                 <th scope="col">{{ previous_year }} score</th>
-                <th scope="col">Change</th>
+                <th scope="col">Versus</th>
             </tr>
         </thead>
         <tbody>
@@ -33,7 +33,7 @@
                     <span class="open-graph-preview__score">{{ last_score|floatformat:0 }}%</span>
                 </td>
                 <td class="align-top">
-                    <span class="open-graph-preview__score">{{ change|floatformat:0 }}</span>
+                    <span class="open-graph-preview__score"><span class="open-graph-preview__score-up">&#9650;</span> {{ change|floatformat:0 }}</span>
                 </td>
             </tr>
         </tbody>


### PR DESCRIPTION
- [ ] Add year to graphics that are not displaying it. For example in the “overall score” -> “Overall score 2025”