### PR TITLE
[Scorecards] Add link to impact survey, above newsletter signup

### DIFF
--- a/scoring/templates/scoring/base-minimal.html
+++ b/scoring/templates/scoring/base-minimal.html
@@ -46,6 +46,14 @@
             <div class="container">
                 <div class="row">
                     <div class="col-12 col-xl-8">
+                        <h2 style="font-size: 1.25em; color: rgb(67, 67, 67); font-weight: 700;">
+                            <strong style="background-color: #CD3A18; font-size: 0.5em; display: inline-block; vertical-align: 0.35em; margin-right: 0.5em;" class="badge">New</strong>
+                            What impact are the Scorecards making in your council?
+                        </h2>
+                        <p style="max-width: 40em">
+                            <a href="https://docs.google.com/forms/d/e/1FAIpQLScVrT3gwjysmOfRk841oStCGc76776w_ZrtWUOoNaN1UYJ8Sg/viewform">Fill out this short survey</a> to let us know your views on the 2025 Action Scorecards and how you have used them. You can also enter a prize draw for a chance to win a £25 voucher (out of 3 available). <strong>We will be collecting responses until 5th January 2026.</strong>
+                        </p>
+                        <hr class="my-5">
                         <div class="newsletter-wrapper p-0">
                             <link href="https://actionnetwork.org/css/style-embed-v3.css" rel="stylesheet" type="text/css" />
                             <script src="//actionnetwork.org/widgets/v5/form/sign-up-to-our-newsletter-9?format=js&amp;source=widget"></script>

--- a/scoring/templates/scoring/base.html
+++ b/scoring/templates/scoring/base.html
@@ -132,6 +132,14 @@
             <div class="container">
                 <div class="row">
                     <div class="col-12 col-xl-8">
+                        <h2 style="font-size: 1.25em; color: rgb(67, 67, 67); font-weight: 700;">
+                            <strong style="background-color: #CD3A18; font-size: 0.5em; display: inline-block; vertical-align: 0.35em; margin-right: 0.5em;" class="badge">New</strong>
+                            What impact are the Scorecards making in your council?
+                        </h2>
+                        <p style="max-width: 40em">
+                            <a href="https://docs.google.com/forms/d/e/1FAIpQLScVrT3gwjysmOfRk841oStCGc76776w_ZrtWUOoNaN1UYJ8Sg/viewform">Fill out this short survey</a> to let us know your views on the 2025 Action Scorecards and how you have used them. You can also enter a prize draw for a chance to win a £25 voucher (out of 3 available). <strong>We will be collecting responses until 5th January 2026.</strong>
+                        </p>
+                        <hr class="my-5">
                         <div class="newsletter-wrapper p-0">
                             <link href="https://actionnetwork.org/css/style-embed-v3.css" rel="stylesheet" type="text/css" />
                             <script src="//actionnetwork.org/widgets/v5/form/sign-up-to-our-newsletter-9?format=js&amp;source=widget"></script>


### PR DESCRIPTION
Fixes #776

Some pretty hacky inline styles here, but seemed fine for a temporary addition.

<img width="1045" height="488" alt="Screenshot 2025-10-31 at 14 44 00" src="https://github.com/user-attachments/assets/d7646c2c-1943-4398-928e-bf4ce81ddecb" />

