### PR TITLE
[Scorecards] Added fix for filter where the url has a type of council

### DIFF
--- a/scoring/static/scoring/js/main.js
+++ b/scoring/static/scoring/js/main.js
@@ -432,6 +432,20 @@ forEachElement('[data-methodology-switch-council-type]', function(trigger){
     });
 });
 
+// Trigger council type filter from URL parameter
+// Example: /sections/?type=combined would make the filter above to select "Combined Authorities"
+(function(){
+    var urlParams = new URLSearchParams(window.location.search);
+    var typeParam = urlParams.get('type');
+
+    if (typeParam) {
+        var trigger = document.querySelector('[data-methodology-switch-council-type="' + typeParam + '"]');
+        if (trigger) {
+            trigger.click();
+        }
+    }
+})();
+
 // Previous year comparison toggle on council page
 forEachElement('#js-toggle-previous-year-score', function(el) {
     el.addEventListener('change', function() {


### PR DESCRIPTION
Currently, in a single section page where we display a message advising users the Combined Authorities don't have this section, the link "Show all Combined Authority sections" takes them to `/sections/?type=combined` however this URL does not activate the filter in the sections page to display only the CA.

This commit takes in account the arguments in the URL, so the right option is chosen when loading the page


https://github.com/user-attachments/assets/b71c5aab-d244-4999-baef-2d35ff002923

